### PR TITLE
fct fix filtre

### DIFF
--- a/src/components/unified-job-board.tsx
+++ b/src/components/unified-job-board.tsx
@@ -12,6 +12,14 @@ import {
 } from "@/components/ui/select";
 import { apiFetch } from "@/lib/fetch";
 import { type ExternalJob } from "@/types/jobs";
+import {
+    buildFilterIndex,
+    formatLocationForDisplay,
+    matchLocationFilters,
+    normalizeLocations,
+    normalizeSearchText,
+    type NormalizedJobLocation,
+} from "@/lib/location-normalization";
 import { Building2, MapPin, Calendar, ExternalLink, Star } from "lucide-react";
 
 const INTERNSHIPS_URL =
@@ -42,24 +50,6 @@ interface UnifiedJobBoardProps {
     variant?: "full" | "preview";
 }
 
-type ParsedLocation = {
-    city?: string;
-    state?: string;
-    country: string;
-};
-
-function parseLocation(location: string): ParsedLocation {
-    const parts = location.split(",").map((p) => p.trim());
-    if (parts.length === 3) {
-        return { city: parts[0], state: parts[1], country: parts[2] };
-    } else if (parts.length === 2) {
-        // If only one comma, assume city, state and country is USA
-        return { city: parts[0], state: parts[1], country: "USA" };
-    } else {
-        return { state: parts[0], country: "USA" };
-    }
-}
-
 export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProps) {
     const isPreview = variant === "preview";
     const [featuredJobs, setFeaturedJobs] = useState<FeaturedJob[]>([]);
@@ -73,9 +63,6 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
     const [selectedCity, setSelectedCity] = useState<string>("all");
     const [selectedType, setSelectedType] = useState<string>("all");
     const [categories, setCategories] = useState<string[]>([]);
-    const [parsedLocations, setParsedLocations] = useState<ParsedLocation[]>(
-        []
-    );
     const [visibleCount, setVisibleCount] = useState(20);
     const observerRef = useRef<IntersectionObserver | null>(null);
     const currentObservedRef = useRef<Element | null>(null);
@@ -190,34 +177,15 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
             setExternalJobs(externalJobsData);
 
             // Precompute categories and locations
-            const allJobsTemp = [
-                ...featuredJobsData,
-                ...externalJobsData.map((job) => ({
-                    ...job,
-                    featured: false as const,
-                })),
-            ];
+            const allJobsTemp = [...featuredJobsData, ...externalJobsData];
             const cats = new Set<string>();
-            const locs = new Set<ParsedLocation>();
             allJobsTemp.forEach((job) => {
                 if ("category" in job && job.category) cats.add(job.category);
-                if ("locations" in job) {
-                    job.locations.forEach((loc) => {
-                        if (loc.trim() !== "") locs.add(parseLocation(loc));
-                    });
-                } else if ("location" in job && job.location.trim() !== "") {
-                    locs.add(parseLocation(job.location));
-                }
             });
             setCategories(
                 Array.from(cats)
                     .filter((cat) => cat.trim() !== "")
                     .sort()
-            );
-            setParsedLocations(
-                Array.from(locs)
-                    .filter((loc) => loc.country.trim() !== "")
-                    .sort((a, b) => a.country.localeCompare(b.country))
             );
         } catch (e) {
             console.log("Unexpected error in fetchData:", e);
@@ -256,52 +224,53 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
 
     const types = ["internship", "new-grad", "featured"];
 
+    const normalizedLocationsByJob = useMemo(() => {
+        const output = new Map<string, NormalizedJobLocation[]>();
+        allJobs.forEach((job) => {
+            if ("locations" in job) {
+                output.set(
+                    job.id,
+                    job.normalized_locations?.length
+                        ? (job.normalized_locations as NormalizedJobLocation[])
+                        : normalizeLocations(job.locations || [])
+                );
+            } else {
+                output.set(job.id, normalizeLocations(job.location ? [job.location] : []));
+            }
+        });
+        return output;
+    }, [allJobs]);
+
+    const filterIndex = useMemo(() => {
+        const allLocations = Array.from(normalizedLocationsByJob.values()).flat();
+        return buildFilterIndex(allLocations);
+    }, [normalizedLocationsByJob]);
+
     const availableCountries = useMemo(() => {
-        const countries = new Set<string>();
-        parsedLocations.forEach((loc) => countries.add(loc.country));
-        return Array.from(countries).sort();
-    }, [parsedLocations]);
+        return filterIndex.countries;
+    }, [filterIndex]);
 
     const availableStates = useMemo(() => {
         if (selectedCountry === "all") return [];
-        const states = new Set<string>();
-        parsedLocations
-            .filter(
-                (loc) =>
-                    loc.country === selectedCountry &&
-                    loc.state &&
-                    loc.state.trim() !== ""
-            )
-            .forEach((loc) => states.add(loc.state!));
-        return Array.from(states).sort();
-    }, [parsedLocations, selectedCountry]);
+        return filterIndex.statesByCountry[selectedCountry] || [];
+    }, [filterIndex, selectedCountry]);
 
     const availableCities = useMemo(() => {
         if (selectedCountry === "all") return [];
-        const cities = new Set<string>();
-        parsedLocations
-            .filter((loc) => {
-                if (loc.country !== selectedCountry) return false;
-                if (selectedState !== "all" && loc.state !== selectedState)
-                    return false;
-                return loc.city && loc.city.trim() !== "";
-            })
-            .forEach((loc) => cities.add(loc.city!));
-        return Array.from(cities).sort();
-    }, [parsedLocations, selectedCountry, selectedState]);
+        if (selectedState === "all") {
+            return filterIndex.citiesByCountry[selectedCountry] || [];
+        }
+        return (
+            filterIndex.citiesByCountryState[`${selectedCountry}::${selectedState}`] || []
+        );
+    }, [filterIndex, selectedCountry, selectedState]);
 
     const matchesLocation = (job: UnifiedJob): boolean => {
-        if (selectedCountry === "all") return true;
-        const jobLocations =
-            "locations" in job ? job.locations : [job.location];
-        return jobLocations.some((locStr) => {
-            const parsed = parseLocation(locStr);
-            if (parsed.country !== selectedCountry) return false;
-            if (selectedState !== "all" && parsed.state !== selectedState)
-                return false;
-            if (selectedCity !== "all" && parsed.city !== selectedCity)
-                return false;
-            return true;
+        const normalized = normalizedLocationsByJob.get(job.id) || [];
+        return matchLocationFilters(normalized, {
+            countryCode: selectedCountry,
+            regionKey: selectedState,
+            cityKey: selectedCity,
         });
     };
 
@@ -319,14 +288,28 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
             if (job.terms) fields.push(...job.terms);
             if (job.degrees) fields.push(...job.degrees);
         }
-        return fields.join(" ").toLowerCase();
+        const normalizedLocations = normalizedLocationsByJob.get(job.id) || [];
+        fields.push(
+            ...normalizedLocations.map((loc) =>
+                [
+                    loc.normalized.city,
+                    loc.normalized.region,
+                    loc.normalized.country,
+                    loc.raw,
+                ]
+                    .filter(Boolean)
+                    .join(" ")
+            )
+        );
+        return normalizeSearchText(fields.join(" "));
     };
 
     const filteredJobs = useMemo(() => {
         let filtered = allJobs.filter((job) => {
             const searchableText = getSearchableText(job);
-            const regex = searchTerm ? new RegExp(searchTerm, "i") : null;
-            const matchesSearch = !regex || regex.test(searchableText);
+            const normalizedSearch = normalizeSearchText(searchTerm);
+            const matchesSearch =
+                normalizedSearch.length === 0 || searchableText.includes(normalizedSearch);
             const matchesCategory =
                 selectedCategory === "all" ||
                 ("category" in job && job.category === selectedCategory);
@@ -352,7 +335,29 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         selectedCity,
         selectedType,
         limit,
+        normalizedLocationsByJob,
     ]);
+
+    useEffect(() => {
+        if (selectedCountry !== "all" && !availableCountries.some((c) => c.value === selectedCountry)) {
+            setSelectedCountry("all");
+            setSelectedState("all");
+            setSelectedCity("all");
+        }
+    }, [selectedCountry, availableCountries]);
+
+    useEffect(() => {
+        if (selectedState !== "all" && !availableStates.some((s) => s.value === selectedState)) {
+            setSelectedState("all");
+            setSelectedCity("all");
+        }
+    }, [selectedState, availableStates]);
+
+    useEffect(() => {
+        if (selectedCity !== "all" && !availableCities.some((c) => c.value === selectedCity)) {
+            setSelectedCity("all");
+        }
+    }, [selectedCity, availableCities]);
 
     useEffect(() => {
         setVisibleCount(20);
@@ -446,8 +451,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                             <SelectContent>
                                 <SelectItem value="all">All Countries</SelectItem>
                                 {availableCountries.map((country) => (
-                                    <SelectItem key={country} value={country}>
-                                        {country}
+                                    <SelectItem key={country.value} value={country.value}>
+                                        {country.label}
                                     </SelectItem>
                                 ))}
                             </SelectContent>
@@ -469,8 +474,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                         All States
                                     </SelectItem>
                                     {availableStates.map((state) => (
-                                        <SelectItem key={state} value={state}>
-                                            {state}
+                                        <SelectItem key={state.value} value={state.value}>
+                                            {state.label}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -487,8 +492,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                 <SelectContent>
                                     <SelectItem value="all">All Cities</SelectItem>
                                     {availableCities.map((city) => (
-                                        <SelectItem key={city} value={city}>
-                                            {city}
+                                        <SelectItem key={city.value} value={city.value}>
+                                            {city.label}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -573,8 +578,12 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                     <MapPin className="h-4 w-4" />
                                     <span>
                                         {"locations" in job
-                                            ? job.locations.join(", ")
-                                            : job.location}
+                                            ? formatLocationForDisplay(
+                                                  normalizedLocationsByJob.get(job.id) || []
+                                              )
+                                            : formatLocationForDisplay(
+                                                  normalizedLocationsByJob.get(job.id) || []
+                                              )}
                                     </span>
                                 </div>
                                 {"terms" in job &&

--- a/src/lib/location-normalization.ts
+++ b/src/lib/location-normalization.ts
@@ -1,0 +1,518 @@
+export type WorkLocationType = "onsite" | "remote" | "hybrid";
+
+export interface NormalizedGeo {
+  city: string | null;
+  region: string | null;
+  region_code: string | null;
+  country: string | null;
+  country_code: string | null;
+}
+
+export interface NormalizedJobLocation {
+  raw: string;
+  normalized: NormalizedGeo;
+  type: WorkLocationType;
+  unresolved: boolean;
+  confidence: number;
+}
+
+export interface LocationFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface LocationFilterIndex {
+  countries: LocationFilterOption[];
+  statesByCountry: Record<string, LocationFilterOption[]>;
+  citiesByCountry: Record<string, LocationFilterOption[]>;
+  citiesByCountryState: Record<string, LocationFilterOption[]>;
+}
+
+const locationCache = new Map<string, NormalizedJobLocation>();
+
+const COUNTRY_CODE_TO_NAME: Record<string, string> = {
+  US: "United States",
+  CA: "Canada",
+  GB: "United Kingdom",
+  IT: "Italy",
+  FR: "France",
+  ES: "Spain",
+  DE: "Germany",
+  NL: "Netherlands",
+  BE: "Belgium",
+  CH: "Switzerland",
+  IE: "Ireland",
+  PT: "Portugal",
+  SE: "Sweden",
+  NO: "Norway",
+  FI: "Finland",
+  DK: "Denmark",
+  PL: "Poland",
+  IN: "India",
+  SG: "Singapore",
+  AU: "Australia",
+  NZ: "New Zealand",
+  BR: "Brazil",
+  MX: "Mexico",
+  JP: "Japan",
+  KR: "South Korea",
+  CN: "China",
+  AE: "United Arab Emirates",
+  IL: "Israel",
+};
+
+const COUNTRY_ALIAS_TO_CODE: Record<string, string> = {
+  usa: "US",
+  us: "US",
+  "united states": "US",
+  "united states of america": "US",
+  america: "US",
+  ca: "CA",
+  can: "CA",
+  canada: "CA",
+  uk: "GB",
+  gb: "GB",
+  "united kingdom": "GB",
+  england: "GB",
+  italy: "IT",
+  france: "FR",
+  spain: "ES",
+  germany: "DE",
+  netherlands: "NL",
+  belgium: "BE",
+  switzerland: "CH",
+  ireland: "IE",
+  portugal: "PT",
+  sweden: "SE",
+  norway: "NO",
+  finland: "FI",
+  denmark: "DK",
+  poland: "PL",
+  india: "IN",
+  singapore: "SG",
+  australia: "AU",
+  "new zealand": "NZ",
+  brazil: "BR",
+  mexico: "MX",
+  japan: "JP",
+  "south korea": "KR",
+  korea: "KR",
+  china: "CN",
+  uae: "AE",
+  israel: "IL",
+};
+
+const US_STATES: Record<string, string> = {
+  AL: "Alabama",
+  AK: "Alaska",
+  AZ: "Arizona",
+  AR: "Arkansas",
+  CA: "California",
+  CO: "Colorado",
+  CT: "Connecticut",
+  DE: "Delaware",
+  FL: "Florida",
+  GA: "Georgia",
+  HI: "Hawaii",
+  ID: "Idaho",
+  IL: "Illinois",
+  IN: "Indiana",
+  IA: "Iowa",
+  KS: "Kansas",
+  KY: "Kentucky",
+  LA: "Louisiana",
+  ME: "Maine",
+  MD: "Maryland",
+  MA: "Massachusetts",
+  MI: "Michigan",
+  MN: "Minnesota",
+  MS: "Mississippi",
+  MO: "Missouri",
+  MT: "Montana",
+  NE: "Nebraska",
+  NV: "Nevada",
+  NH: "New Hampshire",
+  NJ: "New Jersey",
+  NM: "New Mexico",
+  NY: "New York",
+  NC: "North Carolina",
+  ND: "North Dakota",
+  OH: "Ohio",
+  OK: "Oklahoma",
+  OR: "Oregon",
+  PA: "Pennsylvania",
+  RI: "Rhode Island",
+  SC: "South Carolina",
+  SD: "South Dakota",
+  TN: "Tennessee",
+  TX: "Texas",
+  UT: "Utah",
+  VT: "Vermont",
+  VA: "Virginia",
+  WA: "Washington",
+  WV: "West Virginia",
+  WI: "Wisconsin",
+  WY: "Wyoming",
+  DC: "District of Columbia",
+};
+
+const CANADA_PROVINCES: Record<string, string> = {
+  AB: "Alberta",
+  BC: "British Columbia",
+  MB: "Manitoba",
+  NB: "New Brunswick",
+  NL: "Newfoundland and Labrador",
+  NS: "Nova Scotia",
+  NT: "Northwest Territories",
+  NU: "Nunavut",
+  ON: "Ontario",
+  PE: "Prince Edward Island",
+  QC: "Quebec",
+  SK: "Saskatchewan",
+  YT: "Yukon",
+};
+
+const CITY_ALIAS_MAP: Record<string, string> = {
+  sf: "San Francisco",
+  nyc: "New York",
+  la: "Los Angeles",
+};
+
+const CANONICAL_ACCENTED_CITY: Record<string, string> = {
+  montreal: "Montréal",
+  quebec: "Québec",
+};
+
+function normalizeText(text: string): string {
+  return text
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function toSlug(value: string): string {
+  return normalizeText(value).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function cleanRawLocation(rawLocation: string): string {
+  return rawLocation
+    .replace(/\s+/g, " ")
+    .replace(/\s*,\s*/g, ", ")
+    .replace(/\s+-\s+/g, " - ")
+    .trim();
+}
+
+function stripDecorators(text: string): string {
+  return text
+    .replace(/\bgreater\b/gi, "")
+    .replace(/\bmetro(politan)?\b/gi, "")
+    .replace(/\bmetropolitan city of\b/gi, "")
+    .replace(/\barea\b/gi, "")
+    .replace(/\bregion\b/gi, "")
+    .replace(/\s+/g, " ")
+    .replace(/,\s*,/g, ",")
+    .trim();
+}
+
+function resolveCountry(input: string | null): { code: string | null; name: string | null } {
+  if (!input) return { code: null, name: null };
+  const key = normalizeText(input);
+  const code = COUNTRY_ALIAS_TO_CODE[key] || null;
+  if (!code) return { code: null, name: null };
+  return { code, name: COUNTRY_CODE_TO_NAME[code] || null };
+}
+
+function resolveRegion(
+  input: string | null,
+  preferredCountryCode: string | null
+): { code: string | null; name: string | null; countryCode: string | null } {
+  if (!input) return { code: null, name: null, countryCode: preferredCountryCode };
+  const compact = input.trim();
+  const upper = compact.toUpperCase();
+  const key = normalizeText(compact);
+
+  if (preferredCountryCode === "CA" || !preferredCountryCode) {
+    if (CANADA_PROVINCES[upper]) {
+      return { code: upper, name: CANADA_PROVINCES[upper], countryCode: "CA" };
+    }
+    const province = Object.entries(CANADA_PROVINCES).find(
+      ([, v]) => normalizeText(v) === key
+    );
+    if (province) return { code: province[0], name: province[1], countryCode: "CA" };
+  }
+
+  if (preferredCountryCode === "US" || !preferredCountryCode) {
+    if (US_STATES[upper]) {
+      return { code: upper, name: US_STATES[upper], countryCode: "US" };
+    }
+    const state = Object.entries(US_STATES).find(([, v]) => normalizeText(v) === key);
+    if (state) return { code: state[0], name: state[1], countryCode: "US" };
+  }
+
+  return { code: null, name: titleCase(compact), countryCode: preferredCountryCode };
+}
+
+function canonicalCity(input: string | null): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const alias = CITY_ALIAS_MAP[normalizeText(trimmed)];
+  const city = alias || titleCase(trimmed);
+  return CANONICAL_ACCENTED_CITY[normalizeText(city)] || city;
+}
+
+function classifyType(raw: string): WorkLocationType {
+  const lowered = normalizeText(raw);
+  if (/\bremote\b/.test(lowered)) return "remote";
+  if (/\bhybrid\b/.test(lowered)) return "hybrid";
+  return "onsite";
+}
+
+export function normalizeLocation(rawLocation: string): NormalizedJobLocation {
+  const cacheKey = rawLocation || "";
+  const cached = locationCache.get(cacheKey);
+  if (cached) return cached;
+
+  const cleaned = cleanRawLocation(rawLocation || "");
+  const locationType = classifyType(cleaned);
+  const stripped = stripDecorators(cleaned);
+  const parts = stripped
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  let city: string | null = null;
+  let region: string | null = null;
+  let regionCode: string | null = null;
+  let country: string | null = null;
+  let countryCode: string | null = null;
+
+  if (parts.length >= 3) {
+    city = canonicalCity(parts[0]);
+    const r = resolveRegion(parts[1], null);
+    region = r.name;
+    regionCode = r.code;
+    const c = resolveCountry(parts[2]);
+    country = c.name;
+    countryCode = c.code;
+    if (!countryCode && r.countryCode) {
+      countryCode = r.countryCode;
+      country = COUNTRY_CODE_TO_NAME[countryCode] || null;
+    }
+  } else if (parts.length === 2) {
+    city = canonicalCity(parts[0]);
+    const c = resolveCountry(parts[1]);
+    if (c.code) {
+      countryCode = c.code;
+      country = c.name;
+    } else {
+      const r = resolveRegion(parts[1], null);
+      region = r.name;
+      regionCode = r.code;
+      countryCode = r.countryCode;
+      country = countryCode ? COUNTRY_CODE_TO_NAME[countryCode] : null;
+    }
+  } else if (parts.length === 1) {
+    const single = parts[0];
+    const c = resolveCountry(single);
+    if (c.code) {
+      countryCode = c.code;
+      country = c.name;
+    } else {
+      const r = resolveRegion(single, null);
+      if (r.code) {
+        region = r.name;
+        regionCode = r.code;
+        countryCode = r.countryCode;
+        country = countryCode ? COUNTRY_CODE_TO_NAME[countryCode] : null;
+      } else {
+        city = canonicalCity(single);
+      }
+    }
+  }
+
+  if ((locationType === "remote" || locationType === "hybrid") && parts.length > 0) {
+    const inMatch = cleaned.match(/\bin\s+([A-Za-z ]+)$/i);
+    if (inMatch?.[1]) {
+      const c = resolveCountry(inMatch[1]);
+      if (c.code) {
+        countryCode = c.code;
+        country = c.name;
+      }
+    }
+  }
+
+  if (!countryCode && regionCode && CANADA_PROVINCES[regionCode]) {
+    countryCode = "CA";
+    country = COUNTRY_CODE_TO_NAME.CA;
+  }
+  if (!countryCode && regionCode && US_STATES[regionCode]) {
+    countryCode = "US";
+    country = COUNTRY_CODE_TO_NAME.US;
+  }
+
+  const unresolved = !(country || region || city);
+  const result: NormalizedJobLocation = {
+    raw: rawLocation || "",
+    normalized: {
+      city,
+      region,
+      region_code: regionCode,
+      country,
+      country_code: countryCode,
+    },
+    type: locationType,
+    unresolved,
+    confidence: unresolved ? 0.2 : country ? 1 : 0.7,
+  };
+  locationCache.set(cacheKey, result);
+  return result;
+}
+
+export function normalizeLocations(rawLocations: string[]): NormalizedJobLocation[] {
+  const seen = new Set<string>();
+  const normalized: NormalizedJobLocation[] = [];
+  for (const raw of rawLocations || []) {
+    const entry = normalizeLocation(raw);
+    const key = [
+      entry.type,
+      entry.normalized.country_code || entry.normalized.country || "",
+      entry.normalized.region_code || entry.normalized.region || "",
+      entry.normalized.city || "",
+    ].join("::");
+    if (!seen.has(key)) {
+      seen.add(key);
+      normalized.push(entry);
+    }
+  }
+  return normalized;
+}
+
+function normalizeOptionList(options: LocationFilterOption[]): LocationFilterOption[] {
+  return options.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function buildFilterIndex(locations: NormalizedJobLocation[]): LocationFilterIndex {
+  const countryMap = new Map<string, string>();
+  const statesByCountry = new Map<string, Map<string, string>>();
+  const citiesByCountry = new Map<string, Map<string, string>>();
+  const citiesByCountryState = new Map<string, Map<string, string>>();
+
+  for (const location of locations) {
+    if (location.unresolved) continue;
+    if (location.type !== "onsite" && location.type !== "hybrid") continue;
+    const cCode = location.normalized.country_code;
+    const cName = location.normalized.country;
+    if (!cCode || !cName) continue;
+    countryMap.set(cCode, cName);
+
+    const regionKey = location.normalized.region_code || (location.normalized.region ? toSlug(location.normalized.region) : "");
+    if (location.normalized.region && regionKey) {
+      if (!statesByCountry.has(cCode)) statesByCountry.set(cCode, new Map());
+      statesByCountry.get(cCode)!.set(regionKey, location.normalized.region);
+    }
+
+    if (location.normalized.city) {
+      const cityKey = toSlug(location.normalized.city);
+      if (!citiesByCountry.has(cCode)) citiesByCountry.set(cCode, new Map());
+      citiesByCountry.get(cCode)!.set(cityKey, location.normalized.city);
+
+      const stateScope = `${cCode}::${regionKey || "__none__"}`;
+      if (!citiesByCountryState.has(stateScope)) citiesByCountryState.set(stateScope, new Map());
+      citiesByCountryState.get(stateScope)!.set(cityKey, location.normalized.city);
+    }
+  }
+
+  const countries = normalizeOptionList(
+    Array.from(countryMap.entries()).map(([value, label]) => ({ value, label }))
+  );
+
+  const statesObj: Record<string, LocationFilterOption[]> = {};
+  for (const [countryCode, states] of statesByCountry.entries()) {
+    statesObj[countryCode] = normalizeOptionList(
+      Array.from(states.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  const citiesCountryObj: Record<string, LocationFilterOption[]> = {};
+  for (const [countryCode, cities] of citiesByCountry.entries()) {
+    citiesCountryObj[countryCode] = normalizeOptionList(
+      Array.from(cities.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  const citiesCountryStateObj: Record<string, LocationFilterOption[]> = {};
+  for (const [scope, cities] of citiesByCountryState.entries()) {
+    citiesCountryStateObj[scope] = normalizeOptionList(
+      Array.from(cities.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  return {
+    countries,
+    statesByCountry: statesObj,
+    citiesByCountry: citiesCountryObj,
+    citiesByCountryState: citiesCountryStateObj,
+  };
+}
+
+export function matchLocationFilters(
+  locations: NormalizedJobLocation[],
+  filters: { countryCode: string; regionKey: string; cityKey: string }
+): boolean {
+  if (filters.countryCode === "all") return true;
+  return locations.some((location) => {
+    const countryOk =
+      location.normalized.country_code === filters.countryCode ||
+      normalizeText(location.normalized.country || "") === normalizeText(filters.countryCode);
+    if (!countryOk) return false;
+
+    if (filters.regionKey !== "all") {
+      const regionKey =
+        location.normalized.region_code ||
+        (location.normalized.region ? toSlug(location.normalized.region) : "");
+      if (regionKey !== filters.regionKey) return false;
+    }
+
+    if (filters.cityKey !== "all") {
+      const cityKey = location.normalized.city ? toSlug(location.normalized.city) : "";
+      if (cityKey !== filters.cityKey) return false;
+    }
+    return true;
+  });
+}
+
+export function normalizeSearchText(input: string): string {
+  return normalizeText(input);
+}
+
+export function formatLocationForDisplay(locations: NormalizedJobLocation[]): string {
+  const display = new Set<string>();
+  for (const location of locations) {
+    if (location.type === "remote") {
+      const country = location.normalized.country;
+      display.add(country ? `Remote (${country})` : "Remote");
+      continue;
+    }
+    const parts = [
+      location.normalized.city,
+      location.normalized.region_code || location.normalized.region,
+      location.normalized.country_code,
+    ].filter(Boolean);
+    if (parts.length) {
+      display.add(parts.join(", "));
+    } else if (location.raw.trim()) {
+      display.add(location.raw.trim());
+    }
+  }
+  return Array.from(display).join(" | ");
+}

--- a/src/types/jobs.ts
+++ b/src/types/jobs.ts
@@ -58,6 +58,19 @@ export interface ExternalJob {
   date_posted: number;
   url: string;
   locations: string[];
+  normalized_locations?: {
+    raw: string;
+    normalized: {
+      city: string | null;
+      region: string | null;
+      region_code: string | null;
+      country: string | null;
+      country_code: string | null;
+    };
+    type: "onsite" | "remote" | "hybrid";
+    unresolved: boolean;
+    confidence: number;
+  }[];
   degrees: string[];
   type: "internship" | "new-grad";
 }


### PR DESCRIPTION
## Summary
- Refactorise la logique de filtre géographique avec une normalisation structurée des locations.
- Corrige la cascade pays/etat/ville pour supprimer les mélanges et doublons incohérents.
- Ajoute un matching/search accent-insensitive et une base de données de filtres dérivée des données normalisées.

## Test plan
- [x] Vérifier l’affichage des dropdowns pays/etat/ville sans pollution cross-level.
- [x] Vérifier le reset des filtres enfants quand le parent change.
- [x] Vérifier la recherche sur variantes accentuées et alias courants.

Made with [Cursor](https://cursor.com)