### PR TITLE
fct fix filtre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -459,7 +460,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -476,7 +476,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -493,7 +492,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -510,7 +508,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -527,7 +524,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -544,7 +540,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -561,7 +556,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,7 +572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,7 +588,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -612,7 +604,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,7 +620,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,7 +636,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,7 +652,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,7 +668,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,7 +684,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,7 +700,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,7 +716,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -748,7 +732,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,7 +748,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,7 +764,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,7 +780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -816,7 +796,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,7 +812,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,7 +828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,7 +844,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,7 +860,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1135,6 +1110,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
       "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.18",
         "@firebase/logger": "0.4.4",
@@ -1201,6 +1177,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
       "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.2",
         "@firebase/component": "0.6.18",
@@ -1216,7 +1193,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.8",
@@ -1667,6 +1645,7 @@
       "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1694,6 +1673,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3588,7 +3568,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3602,7 +3581,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3616,7 +3594,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3630,7 +3607,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3644,7 +3620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3658,7 +3633,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,7 +3646,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,7 +3659,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3700,7 +3672,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3714,7 +3685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3728,7 +3698,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3742,7 +3711,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3756,7 +3724,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3770,7 +3737,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3784,7 +3750,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3798,7 +3763,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3812,7 +3776,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3826,7 +3789,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3840,7 +3802,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3854,7 +3815,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3868,7 +3828,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4165,6 +4124,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
       "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4387,6 +4347,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.15.3.tgz",
       "integrity": "sha512-n7y/MF9lAM5qlpuH5IR4/uq+kJPEJpe9NrEiH+NmkO/5KJ6cXzpJ6F4U17sMLf2SNCq+TWN9QK8QzoKxIn50VQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4505,6 +4466,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.15.3.tgz",
       "integrity": "sha512-ycx/BgxR4rc9tf3ZyTdI98Z19yKLFfqM3UN+v42ChuIwkzyr9zyp7kG8dB9xN2lNqrD+5y/HyJobz/VJ7T90gA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4519,6 +4481,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
       "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4667,7 +4630,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -4711,6 +4673,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
       "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -4719,8 +4682,8 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4729,8 +4692,8 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4787,6 +4750,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -5026,6 +4990,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5230,6 +5195,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5561,34 +5527,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cosmiconfig-typescript-loader": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
@@ -5651,7 +5589,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cz-conventional-changelog": {
@@ -5898,7 +5835,6 @@
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5976,6 +5912,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6612,7 +6549,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7260,6 +7196,7 @@
       "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7821,7 +7758,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8051,7 +7987,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8071,7 +8006,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8218,6 +8152,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -8247,6 +8182,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -8295,6 +8231,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.5.tgz",
       "integrity": "sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -8447,6 +8384,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8477,6 +8415,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8489,6 +8428,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
       "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8725,7 +8665,6 @@
       "version": "4.50.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
       "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -9063,7 +9002,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9080,7 +9018,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9098,8 +9035,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9194,6 +9131,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9402,8 +9340,8 @@
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9477,7 +9415,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9495,8 +9432,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/components/unified-job-board.tsx
+++ b/src/components/unified-job-board.tsx
@@ -65,11 +65,12 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
     const [loading, setLoading] = useState(true);
     const [appliedJobIds, setAppliedJobIds] = useState<Set<string>>(new Set());
     const [searchTerm, setSearchTerm] = useState("");
-    const [selectedCategory, setSelectedCategory] = useState<string>("all");
+    const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
     const [selectedCountry, setSelectedCountry] = useState<string>("all");
     const [selectedState, setSelectedState] = useState<string>("all");
     const [selectedCities, setSelectedCities] = useState<string[]>([]);
-    const [selectedType, setSelectedType] = useState<string>("all");
+    const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+    const [selectedWorkModes, setSelectedWorkModes] = useState<Array<"onsite" | "hybrid" | "remote">>([]);
     const [categories, setCategories] = useState<string[]>([]);
     const [visibleCount, setVisibleCount] = useState(20);
     const observerRef = useRef<IntersectionObserver | null>(null);
@@ -230,7 +231,19 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         });
     }, [featuredJobs, externalJobs]);
 
-    const types = ["internship", "new-grad", "featured"];
+    const types = ["internship", "new-grad", "featured"] as const;
+    const workModes = ["onsite", "hybrid", "remote"] as const;
+    type WorkModeValue = (typeof workModes)[number];
+    const typeLabel: Record<(typeof types)[number], string> = {
+        internship: "Internship",
+        "new-grad": "New Grad",
+        featured: "Featured",
+    };
+    const workModeLabel: Record<(typeof workModes)[number], string> = {
+        onsite: "Onsite",
+        hybrid: "Hybrid",
+        remote: "Remote",
+    };
 
     const normalizedLocationsByJob = useMemo(() => {
         const output = new Map<string, NormalizedJobLocation[]>();
@@ -254,42 +267,43 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         return buildFilterIndex(allLocations);
     }, [normalizedLocationsByJob]);
 
-    const availableCountries = useMemo(() => {
-        return filterIndex.countries;
-    }, [filterIndex]);
-
-    const availableStates = useMemo(() => {
-        if (selectedCountry === "all") return [];
-        return filterIndex.statesByCountry[selectedCountry] || [];
-    }, [filterIndex, selectedCountry]);
-
-    const availableCities = useMemo(() => {
-        if (selectedCountry === "all") return [];
-        if (selectedState === "all") {
-            return filterIndex.citiesByCountry[selectedCountry] || [];
-        }
-        return (
-            filterIndex.citiesByCountryState[`${selectedCountry}::${selectedState}`] || []
-        );
-    }, [filterIndex, selectedCountry, selectedState]);
-
     const cityToKey = (city: string): string =>
         normalizeSearchText(city).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    const normalizedSearch = useMemo(() => normalizeSearchText(searchTerm), [searchTerm]);
 
-    const matchesLocation = (job: UnifiedJob): boolean => {
-        const normalized = normalizedLocationsByJob.get(job.id) || [];
-        const baseMatch = matchLocationFilters(normalized, {
-            countryCode: selectedCountry,
-            regionKey: selectedState,
-            cityKey: "all",
-        });
-        if (!baseMatch) return false;
-        if (selectedCities.length === 0) return true;
-        return normalized.some((location) => {
-            const cityKey = location.normalized.city ? cityToKey(location.normalized.city) : "";
-            return selectedCities.includes(cityKey);
-        });
+    type ActiveFilters = {
+        types: string[];
+        categories: string[];
+        workModes: Array<"onsite" | "hybrid" | "remote">;
+        country: string;
+        state: string;
+        cities: string[];
+        search: string;
     };
+
+    const activeFilters: ActiveFilters = useMemo(
+        () => ({
+            types: selectedTypes,
+            categories: selectedCategories,
+            workModes: selectedWorkModes,
+            country: selectedCountry,
+            state: selectedState,
+            cities: selectedCities,
+            search: normalizedSearch,
+        }),
+        [
+            selectedTypes,
+            selectedCategories,
+            selectedWorkModes,
+            selectedCountry,
+            selectedState,
+            selectedCities,
+            normalizedSearch,
+        ]
+    );
+
+    const getJobTypeValue = (job: UnifiedJob): string =>
+        job.featured ? "featured" : job.type;
 
     const getSearchableText = (job: UnifiedJob): string => {
         const fields: string[] = [];
@@ -321,38 +335,233 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         return normalizeSearchText(fields.join(" "));
     };
 
-    const filteredJobs = useMemo(() => {
-        let filtered = allJobs.filter((job) => {
-            const searchableText = getSearchableText(job);
-            const normalizedSearch = normalizeSearchText(searchTerm);
-            const matchesSearch =
-                normalizedSearch.length === 0 || searchableText.includes(normalizedSearch);
-            const matchesCategory =
-                selectedCategory === "all" ||
-                ("category" in job && job.category === selectedCategory);
-            const matchesLocationFilter = matchesLocation(job);
-            const jobType = job.featured ? "featured" : job.type;
-            const matchesType =
-                selectedType === "all" || jobType === selectedType;
-            return (
-                matchesSearch &&
-                matchesCategory &&
-                matchesLocationFilter &&
-                matchesType
-            );
+    const matchJobWithFilters = (
+        job: UnifiedJob,
+        filters: ActiveFilters,
+        ignoreFacet?: "types" | "categories" | "workModes" | "countries" | "states" | "cities"
+    ): boolean => {
+        const searchableText = getSearchableText(job);
+        const matchesSearch = filters.search.length === 0 || searchableText.includes(filters.search);
+        if (!matchesSearch) return false;
+
+        const jobType = getJobTypeValue(job);
+        if (ignoreFacet !== "types" && filters.types.length > 0 && !filters.types.includes(jobType)) {
+            return false;
+        }
+
+        const category = "category" in job ? job.category : null;
+        if (
+            ignoreFacet !== "categories" &&
+            filters.categories.length > 0 &&
+            (!category || !filters.categories.includes(category))
+        ) {
+            return false;
+        }
+
+        const normalized = normalizedLocationsByJob.get(job.id) || [];
+        if (
+            ignoreFacet !== "workModes" &&
+            filters.workModes.length > 0 &&
+            !normalized.some((loc) => filters.workModes.includes(loc.type))
+        ) {
+            return false;
+        }
+
+        if (
+            ignoreFacet !== "countries" &&
+            !matchLocationFilters(normalized, {
+                countryCode: filters.country,
+                regionKey: "all",
+                cityKey: "all",
+            })
+        ) {
+            return false;
+        }
+
+        if (
+            ignoreFacet !== "states" &&
+            !matchLocationFilters(normalized, {
+                countryCode: filters.country,
+                regionKey: filters.state,
+                cityKey: "all",
+            })
+        ) {
+            return false;
+        }
+
+        if (ignoreFacet !== "cities" && filters.cities.length > 0) {
+            const cityMatch = normalized.some((location) => {
+                if (!location.normalized.city) return false;
+                const cityKey = cityToKey(location.normalized.city);
+                if (filters.country !== "all" && location.normalized.country_code !== filters.country) return false;
+                if (
+                    filters.state !== "all" &&
+                    (location.normalized.region_code ||
+                        (location.normalized.region
+                            ? normalizeSearchText(location.normalized.region)
+                                  .replace(/[^a-z0-9]+/g, "-")
+                                  .replace(/^-|-$/g, "")
+                            : "")) !== filters.state
+                ) {
+                    return false;
+                }
+                return filters.cities.includes(cityKey);
+            });
+            if (!cityMatch) return false;
+        }
+
+        return true;
+    };
+
+    const computeFacetCounts = (
+        facet: "types" | "categories" | "workModes" | "countries" | "states" | "cities"
+    ): Map<string, number> => {
+        const counts = new Map<string, number>();
+        allJobs.forEach((job) => {
+            if (!matchJobWithFilters(job, activeFilters, facet)) return;
+            const normalized = normalizedLocationsByJob.get(job.id) || [];
+            const values = new Set<string>();
+            if (facet === "types") {
+                values.add(getJobTypeValue(job));
+            } else if (facet === "categories") {
+                if ("category" in job && job.category) values.add(job.category);
+            } else if (facet === "workModes") {
+                normalized.forEach((loc) => values.add(loc.type));
+            } else if (facet === "countries") {
+                normalized.forEach((loc) => {
+                    if (loc.normalized.country_code) values.add(loc.normalized.country_code);
+                });
+            } else if (facet === "states" && selectedCountry !== "all") {
+                normalized.forEach((loc) => {
+                    if (loc.normalized.country_code !== selectedCountry) return;
+                    const stateKey =
+                        loc.normalized.region_code ||
+                        (loc.normalized.region
+                            ? normalizeSearchText(loc.normalized.region)
+                                  .replace(/[^a-z0-9]+/g, "-")
+                                  .replace(/^-|-$/g, "")
+                            : "");
+                    if (stateKey) values.add(stateKey);
+                });
+            } else if (facet === "cities" && selectedCountry !== "all") {
+                normalized.forEach((loc) => {
+                    if (loc.normalized.country_code !== selectedCountry) return;
+                    const stateKey =
+                        loc.normalized.region_code ||
+                        (loc.normalized.region
+                            ? normalizeSearchText(loc.normalized.region)
+                                  .replace(/[^a-z0-9]+/g, "-")
+                                  .replace(/^-|-$/g, "")
+                            : "");
+                    if (selectedState !== "all" && stateKey !== selectedState) return;
+                    if (loc.normalized.city) values.add(cityToKey(loc.normalized.city));
+                });
+            }
+            values.forEach((value) => {
+                counts.set(value, (counts.get(value) || 0) + 1);
+            });
         });
+        return counts;
+    };
+
+    const typeCounts = useMemo(() => computeFacetCounts("types"), [allJobs, activeFilters, normalizedLocationsByJob]);
+    const categoryCounts = useMemo(() => computeFacetCounts("categories"), [allJobs, activeFilters, normalizedLocationsByJob]);
+    const workModeCounts = useMemo(() => computeFacetCounts("workModes"), [allJobs, activeFilters, normalizedLocationsByJob]);
+    const countryCounts = useMemo(() => computeFacetCounts("countries"), [allJobs, activeFilters, normalizedLocationsByJob]);
+    const stateCounts = useMemo(() => computeFacetCounts("states"), [allJobs, activeFilters, normalizedLocationsByJob, selectedCountry]);
+    const cityCounts = useMemo(() => computeFacetCounts("cities"), [allJobs, activeFilters, normalizedLocationsByJob, selectedCountry, selectedState]);
+
+    const sortByCountThenLabel = (
+        items: Array<{ value: string; label: string; count: number }>
+    ) =>
+        items.sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            return a.label.localeCompare(b.label);
+        });
+
+    const availableTypeOptions = useMemo(
+        () =>
+            sortByCountThenLabel(
+                types.map((type) => ({
+                    value: type,
+                    label: typeLabel[type],
+                    count: typeCounts.get(type) || 0,
+                }))
+            ).filter((opt) => opt.count > 0 || selectedTypes.includes(opt.value)),
+        [typeCounts, selectedTypes]
+    );
+
+    const availableCategoryOptions = useMemo(
+        () =>
+            sortByCountThenLabel(
+                categories.map((category) => ({
+                    value: category,
+                    label: category,
+                    count: categoryCounts.get(category) || 0,
+                }))
+            ).filter((opt) => opt.count > 0 || selectedCategories.includes(opt.value)),
+        [categories, categoryCounts, selectedCategories]
+    );
+
+    const availableWorkModeOptions = useMemo(
+        () =>
+            sortByCountThenLabel(
+            workModes.map((mode) => ({
+                    value: mode,
+                    label: workModeLabel[mode],
+                    count: workModeCounts.get(mode) || 0,
+                }))
+            ).filter((opt) => opt.count > 0 || selectedWorkModes.includes(opt.value)),
+        [workModeCounts, selectedWorkModes]
+    );
+
+    const availableCountries = useMemo(
+        () =>
+            sortByCountThenLabel(
+                filterIndex.countries.map((country) => ({
+                    value: country.value,
+                    label: country.label,
+                    count: countryCounts.get(country.value) || 0,
+                }))
+            ).filter((opt) => opt.count > 0 || selectedCountry === opt.value),
+        [filterIndex, countryCounts, selectedCountry]
+    );
+
+    const availableStates = useMemo(() => {
+        if (selectedCountry === "all") return [];
+        const states = filterIndex.statesByCountry[selectedCountry] || [];
+        return sortByCountThenLabel(
+            states.map((state) => ({
+                value: state.value,
+                label: state.label,
+                count: stateCounts.get(state.value) || 0,
+            }))
+        ).filter((opt) => opt.count > 0 || selectedState === opt.value);
+    }, [filterIndex, selectedCountry, stateCounts, selectedState]);
+
+    const availableCities = useMemo(() => {
+        if (selectedCountry === "all") return [];
+        const cities =
+            selectedState === "all"
+                ? filterIndex.citiesByCountry[selectedCountry] || []
+                : filterIndex.citiesByCountryState[`${selectedCountry}::${selectedState}`] || [];
+        return sortByCountThenLabel(
+            cities.map((city) => ({
+                value: city.value,
+                label: city.label,
+                count: cityCounts.get(city.value) || 0,
+            }))
+        ).filter((opt) => opt.count > 0 || selectedCities.includes(opt.value));
+    }, [filterIndex, selectedCountry, selectedState, cityCounts, selectedCities]);
+
+    const filteredJobs = useMemo(() => {
+        let filtered = allJobs.filter((job) => matchJobWithFilters(job, activeFilters));
         if (limit) filtered = filtered.slice(0, limit);
         return filtered;
     }, [
         allJobs,
-        searchTerm,
-        selectedCategory,
-        selectedCountry,
-        selectedState,
-        selectedCities,
-        selectedType,
+        activeFilters,
         limit,
-        normalizedLocationsByJob,
     ]);
 
     useEffect(() => {
@@ -374,6 +583,23 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         const citySet = new Set(availableCities.map((c) => c.value));
         setSelectedCities((prev) => prev.filter((city) => citySet.has(city)));
     }, [availableCities]);
+
+    useEffect(() => {
+        const typeSet = new Set(availableTypeOptions.map((opt) => opt.value));
+        setSelectedTypes((prev) => prev.filter((type) => typeSet.has(type)));
+    }, [availableTypeOptions]);
+
+    useEffect(() => {
+        const categorySet = new Set(availableCategoryOptions.map((opt) => opt.value));
+        setSelectedCategories((prev) => prev.filter((category) => categorySet.has(category)));
+    }, [availableCategoryOptions]);
+
+    useEffect(() => {
+        const modeSet = new Set(availableWorkModeOptions.map((opt) => opt.value));
+        setSelectedWorkModes((prev) =>
+            prev.filter((mode) => modeSet.has(mode))
+        );
+    }, [availableWorkModeOptions]);
 
     useEffect(() => {
         setVisibleCount(20);
@@ -418,41 +644,99 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                             onChange={(e) => setSearchTerm(e.target.value)}
                             className="w-64"
                         />
-                        <Select
-                            value={selectedType}
-                            onValueChange={setSelectedType}
-                        >
-                            <SelectTrigger className="w-full sm:w-32">
-                                <SelectValue placeholder="Type" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="all">All Types</SelectItem>
-                                {types.map((type) => (
-                                    <SelectItem key={type} value={type}>
-                                        {type === "new-grad"
-                                            ? "New Grad"
-                                            : type.charAt(0).toUpperCase() +
-                                              type.slice(1)}
-                                    </SelectItem>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" className="w-full sm:w-40 justify-start font-normal">
+                                    {selectedTypes.length === 0
+                                        ? "All Types"
+                                        : selectedTypes.length === 1
+                                          ? "1 type selected"
+                                          : `${selectedTypes.length} types selected`}
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-64 max-h-72 overflow-y-auto">
+                                <DropdownMenuItem onClick={() => setSelectedTypes([])}>
+                                    Clear type filters
+                                </DropdownMenuItem>
+                                {availableTypeOptions.map((type) => (
+                                    <DropdownMenuCheckboxItem
+                                        key={type.value}
+                                        checked={selectedTypes.includes(type.value)}
+                                        onCheckedChange={(checked) => {
+                                            setSelectedTypes((prev) =>
+                                                checked
+                                                    ? [...prev, type.value]
+                                                    : prev.filter((value) => value !== type.value)
+                                            );
+                                        }}
+                                    >
+                                        {type.label} ({type.count})
+                                    </DropdownMenuCheckboxItem>
                                 ))}
-                            </SelectContent>
-                        </Select>
-                        <Select
-                            value={selectedCategory}
-                            onValueChange={setSelectedCategory}
-                        >
-                            <SelectTrigger className="w-full sm:w-48">
-                                <SelectValue placeholder="Category" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="all">All Categories</SelectItem>
-                                {categories.map((cat) => (
-                                    <SelectItem key={cat} value={cat}>
-                                        {cat}
-                                    </SelectItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" className="w-full sm:w-52 justify-start font-normal">
+                                    {selectedCategories.length === 0
+                                        ? "All Categories"
+                                        : selectedCategories.length === 1
+                                          ? "1 category selected"
+                                          : `${selectedCategories.length} categories selected`}
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-72 max-h-72 overflow-y-auto">
+                                <DropdownMenuItem onClick={() => setSelectedCategories([])}>
+                                    Clear category filters
+                                </DropdownMenuItem>
+                                {availableCategoryOptions.map((category) => (
+                                    <DropdownMenuCheckboxItem
+                                        key={category.value}
+                                        checked={selectedCategories.includes(category.value)}
+                                        onCheckedChange={(checked) => {
+                                            setSelectedCategories((prev) =>
+                                                checked
+                                                    ? [...prev, category.value]
+                                                    : prev.filter((value) => value !== category.value)
+                                            );
+                                        }}
+                                    >
+                                        {category.label} ({category.count})
+                                    </DropdownMenuCheckboxItem>
                                 ))}
-                            </SelectContent>
-                        </Select>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" className="w-full sm:w-44 justify-start font-normal">
+                                    {selectedWorkModes.length === 0
+                                        ? "All Work Modes"
+                                        : selectedWorkModes.length === 1
+                                          ? "1 mode selected"
+                                          : `${selectedWorkModes.length} modes selected`}
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-56 max-h-72 overflow-y-auto">
+                                <DropdownMenuItem onClick={() => setSelectedWorkModes([])}>
+                                    Clear work mode filters
+                                </DropdownMenuItem>
+                                {availableWorkModeOptions.map((mode) => (
+                                    <DropdownMenuCheckboxItem
+                                        key={mode.value}
+                                        checked={selectedWorkModes.includes(mode.value as WorkModeValue)}
+                                        onCheckedChange={(checked) => {
+                                            setSelectedWorkModes((prev) =>
+                                                checked
+                                                    ? [...prev, mode.value as WorkModeValue]
+                                                    : prev.filter((value) => value !== mode.value)
+                                            );
+                                        }}
+                                    >
+                                        {mode.label} ({mode.count})
+                                    </DropdownMenuCheckboxItem>
+                                ))}
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                         <Select
                             value={selectedCountry}
                             onValueChange={(value) => {
@@ -468,7 +752,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                 <SelectItem value="all">All Countries</SelectItem>
                                 {availableCountries.map((country) => (
                                     <SelectItem key={country.value} value={country.value}>
-                                        {country.label}
+                                        {country.label} ({country.count})
                                     </SelectItem>
                                 ))}
                             </SelectContent>
@@ -491,7 +775,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                     </SelectItem>
                                     {availableStates.map((state) => (
                                         <SelectItem key={state.value} value={state.value}>
-                                            {state.label}
+                                            {state.label} ({state.count})
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -527,11 +811,26 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                                 );
                                             }}
                                         >
-                                            {city.label}
+                                            {city.label} ({city.count})
                                         </DropdownMenuCheckboxItem>
                                     ))}
                                 </DropdownMenuContent>
                             </DropdownMenu>
+                        )}
+                        {(selectedCountry !== "all" ||
+                            selectedState !== "all" ||
+                            selectedCities.length > 0) && (
+                            <Button
+                                variant="ghost"
+                                className="w-full sm:w-auto"
+                                onClick={() => {
+                                    setSelectedCountry("all");
+                                    setSelectedState("all");
+                                    setSelectedCities([]);
+                                }}
+                            >
+                                Clear location filters
+                            </Button>
                         )}
                     </div>
                 </div>

--- a/src/components/unified-job-board.tsx
+++ b/src/components/unified-job-board.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import {
     Select,
     SelectContent,
@@ -10,6 +11,13 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { apiFetch } from "@/lib/fetch";
 import { type ExternalJob } from "@/types/jobs";
 import {
@@ -60,7 +68,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
     const [selectedCategory, setSelectedCategory] = useState<string>("all");
     const [selectedCountry, setSelectedCountry] = useState<string>("all");
     const [selectedState, setSelectedState] = useState<string>("all");
-    const [selectedCity, setSelectedCity] = useState<string>("all");
+    const [selectedCities, setSelectedCities] = useState<string[]>([]);
     const [selectedType, setSelectedType] = useState<string>("all");
     const [categories, setCategories] = useState<string[]>([]);
     const [visibleCount, setVisibleCount] = useState(20);
@@ -265,12 +273,21 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         );
     }, [filterIndex, selectedCountry, selectedState]);
 
+    const cityToKey = (city: string): string =>
+        normalizeSearchText(city).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
     const matchesLocation = (job: UnifiedJob): boolean => {
         const normalized = normalizedLocationsByJob.get(job.id) || [];
-        return matchLocationFilters(normalized, {
+        const baseMatch = matchLocationFilters(normalized, {
             countryCode: selectedCountry,
             regionKey: selectedState,
-            cityKey: selectedCity,
+            cityKey: "all",
+        });
+        if (!baseMatch) return false;
+        if (selectedCities.length === 0) return true;
+        return normalized.some((location) => {
+            const cityKey = location.normalized.city ? cityToKey(location.normalized.city) : "";
+            return selectedCities.includes(cityKey);
         });
     };
 
@@ -332,7 +349,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         selectedCategory,
         selectedCountry,
         selectedState,
-        selectedCity,
+        selectedCities,
         selectedType,
         limit,
         normalizedLocationsByJob,
@@ -342,22 +359,21 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         if (selectedCountry !== "all" && !availableCountries.some((c) => c.value === selectedCountry)) {
             setSelectedCountry("all");
             setSelectedState("all");
-            setSelectedCity("all");
+            setSelectedCities([]);
         }
     }, [selectedCountry, availableCountries]);
 
     useEffect(() => {
         if (selectedState !== "all" && !availableStates.some((s) => s.value === selectedState)) {
             setSelectedState("all");
-            setSelectedCity("all");
+            setSelectedCities([]);
         }
     }, [selectedState, availableStates]);
 
     useEffect(() => {
-        if (selectedCity !== "all" && !availableCities.some((c) => c.value === selectedCity)) {
-            setSelectedCity("all");
-        }
-    }, [selectedCity, availableCities]);
+        const citySet = new Set(availableCities.map((c) => c.value));
+        setSelectedCities((prev) => prev.filter((city) => citySet.has(city)));
+    }, [availableCities]);
 
     useEffect(() => {
         setVisibleCount(20);
@@ -442,7 +458,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                             onValueChange={(value) => {
                                 setSelectedCountry(value);
                                 setSelectedState("all");
-                                setSelectedCity("all");
+                                setSelectedCities([]);
                             }}
                         >
                             <SelectTrigger className="w-full sm:w-32">
@@ -463,7 +479,7 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                     value={selectedState}
                                     onValueChange={(value) => {
                                         setSelectedState(value);
-                                        setSelectedCity("all");
+                                        setSelectedCities([]);
                                     }}
                                 >
                                 <SelectTrigger className="w-full sm:w-32">
@@ -482,22 +498,40 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                             </Select>
                         )}
                         {selectedState !== "all" && availableCities.length > 0 && (
-                            <Select
-                                value={selectedCity}
-                                onValueChange={setSelectedCity}
-                            >
-                                <SelectTrigger className="w-full sm:w-32">
-                                    <SelectValue placeholder="City" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="all">All Cities</SelectItem>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        className="w-full sm:w-48 justify-start font-normal"
+                                    >
+                                        {selectedCities.length === 0
+                                            ? "All Cities"
+                                            : selectedCities.length === 1
+                                              ? "1 city selected"
+                                              : `${selectedCities.length} cities selected`}
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent className="w-56 max-h-72 overflow-y-auto">
+                                    <DropdownMenuItem onClick={() => setSelectedCities([])}>
+                                        Clear city filters
+                                    </DropdownMenuItem>
                                     {availableCities.map((city) => (
-                                        <SelectItem key={city.value} value={city.value}>
+                                        <DropdownMenuCheckboxItem
+                                            key={city.value}
+                                            checked={selectedCities.includes(city.value)}
+                                            onCheckedChange={(checked) => {
+                                                setSelectedCities((prev) =>
+                                                    checked
+                                                        ? [...prev, city.value]
+                                                        : prev.filter((value) => value !== city.value)
+                                                );
+                                            }}
+                                        >
                                             {city.label}
-                                        </SelectItem>
+                                        </DropdownMenuCheckboxItem>
                                     ))}
-                                </SelectContent>
-                            </Select>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
                         )}
                     </div>
                 </div>

--- a/src/components/unified-job-board.tsx
+++ b/src/components/unified-job-board.tsx
@@ -12,6 +12,14 @@ import {
 } from "@/components/ui/select";
 import { apiFetch } from "@/lib/fetch";
 import { type ExternalJob } from "@/types/jobs";
+import {
+    buildFilterIndex,
+    formatLocationForDisplay,
+    matchLocationFilters,
+    normalizeLocations,
+    normalizeSearchText,
+    type NormalizedJobLocation,
+} from "@/lib/location-normalization";
 import { Building2, MapPin, Calendar, ExternalLink, Star } from "lucide-react";
 
 const INTERNSHIPS_URL =
@@ -42,24 +50,6 @@ interface UnifiedJobBoardProps {
     variant?: "full" | "preview";
 }
 
-type ParsedLocation = {
-    city?: string;
-    state?: string;
-    country: string;
-};
-
-function parseLocation(location: string): ParsedLocation {
-    const parts = location.split(",").map((p) => p.trim());
-    if (parts.length === 3) {
-        return { city: parts[0], state: parts[1], country: parts[2] };
-    } else if (parts.length === 2) {
-        // If only one comma, assume city, state and country is USA
-        return { city: parts[0], state: parts[1], country: "USA" };
-    } else {
-        return { state: parts[0], country: "USA" };
-    }
-}
-
 export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProps) {
     const isPreview = variant === "preview";
     const [featuredJobs, setFeaturedJobs] = useState<FeaturedJob[]>([]);
@@ -73,9 +63,6 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
     const [selectedCity, setSelectedCity] = useState<string>("all");
     const [selectedType, setSelectedType] = useState<string>("all");
     const [categories, setCategories] = useState<string[]>([]);
-    const [parsedLocations, setParsedLocations] = useState<ParsedLocation[]>(
-        []
-    );
     const [visibleCount, setVisibleCount] = useState(20);
     const observerRef = useRef<IntersectionObserver | null>(null);
     const currentObservedRef = useRef<Element | null>(null);
@@ -190,34 +177,15 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
             setExternalJobs(externalJobsData);
 
             // Precompute categories and locations
-            const allJobsTemp = [
-                ...featuredJobsData,
-                ...externalJobsData.map((job) => ({
-                    ...job,
-                    featured: false as const,
-                })),
-            ];
+            const allJobsTemp = [...featuredJobsData, ...externalJobsData];
             const cats = new Set<string>();
-            const locs = new Set<ParsedLocation>();
             allJobsTemp.forEach((job) => {
                 if ("category" in job && job.category) cats.add(job.category);
-                if ("locations" in job) {
-                    job.locations.forEach((loc) => {
-                        if (loc.trim() !== "") locs.add(parseLocation(loc));
-                    });
-                } else if ("location" in job && job.location.trim() !== "") {
-                    locs.add(parseLocation(job.location));
-                }
             });
             setCategories(
                 Array.from(cats)
                     .filter((cat) => cat.trim() !== "")
                     .sort()
-            );
-            setParsedLocations(
-                Array.from(locs)
-                    .filter((loc) => loc.country.trim() !== "")
-                    .sort((a, b) => a.country.localeCompare(b.country))
             );
         } catch (e) {
             console.log("Unexpected error in fetchData:", e);
@@ -256,52 +224,53 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
 
     const types = ["internship", "new-grad", "featured"];
 
+    const normalizedLocationsByJob = useMemo(() => {
+        const output = new Map<string, NormalizedJobLocation[]>();
+        allJobs.forEach((job) => {
+            if ("locations" in job) {
+                output.set(
+                    job.id,
+                    job.normalized_locations?.length
+                        ? (job.normalized_locations as NormalizedJobLocation[])
+                        : normalizeLocations(job.locations || [])
+                );
+            } else {
+                output.set(job.id, normalizeLocations(job.location ? [job.location] : []));
+            }
+        });
+        return output;
+    }, [allJobs]);
+
+    const filterIndex = useMemo(() => {
+        const allLocations = Array.from(normalizedLocationsByJob.values()).flat();
+        return buildFilterIndex(allLocations);
+    }, [normalizedLocationsByJob]);
+
     const availableCountries = useMemo(() => {
-        const countries = new Set<string>();
-        parsedLocations.forEach((loc) => countries.add(loc.country));
-        return Array.from(countries).sort();
-    }, [parsedLocations]);
+        return filterIndex.countries;
+    }, [filterIndex]);
 
     const availableStates = useMemo(() => {
         if (selectedCountry === "all") return [];
-        const states = new Set<string>();
-        parsedLocations
-            .filter(
-                (loc) =>
-                    loc.country === selectedCountry &&
-                    loc.state &&
-                    loc.state.trim() !== ""
-            )
-            .forEach((loc) => states.add(loc.state!));
-        return Array.from(states).sort();
-    }, [parsedLocations, selectedCountry]);
+        return filterIndex.statesByCountry[selectedCountry] || [];
+    }, [filterIndex, selectedCountry]);
 
     const availableCities = useMemo(() => {
         if (selectedCountry === "all") return [];
-        const cities = new Set<string>();
-        parsedLocations
-            .filter((loc) => {
-                if (loc.country !== selectedCountry) return false;
-                if (selectedState !== "all" && loc.state !== selectedState)
-                    return false;
-                return loc.city && loc.city.trim() !== "";
-            })
-            .forEach((loc) => cities.add(loc.city!));
-        return Array.from(cities).sort();
-    }, [parsedLocations, selectedCountry, selectedState]);
+        if (selectedState === "all") {
+            return filterIndex.citiesByCountry[selectedCountry] || [];
+        }
+        return (
+            filterIndex.citiesByCountryState[`${selectedCountry}::${selectedState}`] || []
+        );
+    }, [filterIndex, selectedCountry, selectedState]);
 
     const matchesLocation = (job: UnifiedJob): boolean => {
-        if (selectedCountry === "all") return true;
-        const jobLocations =
-            "locations" in job ? job.locations : [job.location];
-        return jobLocations.some((locStr) => {
-            const parsed = parseLocation(locStr);
-            if (parsed.country !== selectedCountry) return false;
-            if (selectedState !== "all" && parsed.state !== selectedState)
-                return false;
-            if (selectedCity !== "all" && parsed.city !== selectedCity)
-                return false;
-            return true;
+        const normalized = normalizedLocationsByJob.get(job.id) || [];
+        return matchLocationFilters(normalized, {
+            countryCode: selectedCountry,
+            regionKey: selectedState,
+            cityKey: selectedCity,
         });
     };
 
@@ -319,14 +288,28 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
             if (job.terms) fields.push(...job.terms);
             if (job.degrees) fields.push(...job.degrees);
         }
-        return fields.join(" ").toLowerCase();
+        const normalizedLocations = normalizedLocationsByJob.get(job.id) || [];
+        fields.push(
+            ...normalizedLocations.map((loc) =>
+                [
+                    loc.normalized.city,
+                    loc.normalized.region,
+                    loc.normalized.country,
+                    loc.raw,
+                ]
+                    .filter(Boolean)
+                    .join(" ")
+            )
+        );
+        return normalizeSearchText(fields.join(" "));
     };
 
     const filteredJobs = useMemo(() => {
         let filtered = allJobs.filter((job) => {
             const searchableText = getSearchableText(job);
-            const regex = searchTerm ? new RegExp(searchTerm, "i") : null;
-            const matchesSearch = !regex || regex.test(searchableText);
+            const normalizedSearch = normalizeSearchText(searchTerm);
+            const matchesSearch =
+                normalizedSearch.length === 0 || searchableText.includes(normalizedSearch);
             const matchesCategory =
                 selectedCategory === "all" ||
                 ("category" in job && job.category === selectedCategory);
@@ -352,7 +335,29 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
         selectedCity,
         selectedType,
         limit,
+        normalizedLocationsByJob,
     ]);
+
+    useEffect(() => {
+        if (selectedCountry !== "all" && !availableCountries.some((c) => c.value === selectedCountry)) {
+            setSelectedCountry("all");
+            setSelectedState("all");
+            setSelectedCity("all");
+        }
+    }, [selectedCountry, availableCountries]);
+
+    useEffect(() => {
+        if (selectedState !== "all" && !availableStates.some((s) => s.value === selectedState)) {
+            setSelectedState("all");
+            setSelectedCity("all");
+        }
+    }, [selectedState, availableStates]);
+
+    useEffect(() => {
+        if (selectedCity !== "all" && !availableCities.some((c) => c.value === selectedCity)) {
+            setSelectedCity("all");
+        }
+    }, [selectedCity, availableCities]);
 
     useEffect(() => {
         setVisibleCount(20);
@@ -446,8 +451,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                             <SelectContent>
                                 <SelectItem value="all">All Countries</SelectItem>
                                 {availableCountries.map((country) => (
-                                    <SelectItem key={country} value={country}>
-                                        {country}
+                                    <SelectItem key={country.value} value={country.value}>
+                                        {country.label}
                                     </SelectItem>
                                 ))}
                             </SelectContent>
@@ -469,8 +474,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                         All States
                                     </SelectItem>
                                     {availableStates.map((state) => (
-                                        <SelectItem key={state} value={state}>
-                                            {state}
+                                        <SelectItem key={state.value} value={state.value}>
+                                            {state.label}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -487,8 +492,8 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                 <SelectContent>
                                     <SelectItem value="all">All Cities</SelectItem>
                                     {availableCities.map((city) => (
-                                        <SelectItem key={city} value={city}>
-                                            {city}
+                                        <SelectItem key={city.value} value={city.value}>
+                                            {city.label}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -573,8 +578,12 @@ export function UnifiedJobBoard({ limit, variant = "full" }: UnifiedJobBoardProp
                                     <MapPin className="h-4 w-4" />
                                     <span>
                                         {"locations" in job
-                                            ? job.locations.join(", ")
-                                            : job.location}
+                                            ? formatLocationForDisplay(
+                                                  normalizedLocationsByJob.get(job.id) || []
+                                              )
+                                            : formatLocationForDisplay(
+                                                  normalizedLocationsByJob.get(job.id) || []
+                                              )}
                                     </span>
                                 </div>
                                 {"terms" in job &&

--- a/src/lib/location-normalization.ts
+++ b/src/lib/location-normalization.ts
@@ -67,7 +67,6 @@ const COUNTRY_ALIAS_TO_CODE: Record<string, string> = {
   "united states": "US",
   "united states of america": "US",
   america: "US",
-  ca: "CA",
   can: "CA",
   canada: "CA",
   uk: "GB",
@@ -226,6 +225,8 @@ function stripDecorators(text: string): string {
 function resolveCountry(input: string | null): { code: string | null; name: string | null } {
   if (!input) return { code: null, name: null };
   const key = normalizeText(input);
+  // "CA" est ambigu (Canada vs California). On n'accepte pas "CA" comme pays sans contexte.
+  if (key === "ca") return { code: null, name: null };
   const code = COUNTRY_ALIAS_TO_CODE[key] || null;
   if (!code) return { code: null, name: null };
   return { code, name: COUNTRY_CODE_TO_NAME[code] || null };

--- a/src/lib/location-normalization.ts
+++ b/src/lib/location-normalization.ts
@@ -1,0 +1,518 @@
+export type WorkLocationType = "onsite" | "remote" | "hybrid";
+
+export interface NormalizedGeo {
+  city: string | null;
+  region: string | null;
+  region_code: string | null;
+  country: string | null;
+  country_code: string | null;
+}
+
+export interface NormalizedJobLocation {
+  raw: string;
+  normalized: NormalizedGeo;
+  type: WorkLocationType;
+  unresolved: boolean;
+  confidence: number;
+}
+
+export interface LocationFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface LocationFilterIndex {
+  countries: LocationFilterOption[];
+  statesByCountry: Record<string, LocationFilterOption[]>;
+  citiesByCountry: Record<string, LocationFilterOption[]>;
+  citiesByCountryState: Record<string, LocationFilterOption[]>;
+}
+
+const locationCache = new Map<string, NormalizedJobLocation>();
+
+const COUNTRY_CODE_TO_NAME: Record<string, string> = {
+  US: "United States",
+  CA: "Canada",
+  GB: "United Kingdom",
+  IT: "Italy",
+  FR: "France",
+  ES: "Spain",
+  DE: "Germany",
+  NL: "Netherlands",
+  BE: "Belgium",
+  CH: "Switzerland",
+  IE: "Ireland",
+  PT: "Portugal",
+  SE: "Sweden",
+  NO: "Norway",
+  FI: "Finland",
+  DK: "Denmark",
+  PL: "Poland",
+  IN: "India",
+  SG: "Singapore",
+  AU: "Australia",
+  NZ: "New Zealand",
+  BR: "Brazil",
+  MX: "Mexico",
+  JP: "Japan",
+  KR: "South Korea",
+  CN: "China",
+  AE: "United Arab Emirates",
+  IL: "Israel",
+};
+
+const COUNTRY_ALIAS_TO_CODE: Record<string, string> = {
+  usa: "US",
+  us: "US",
+  "united states": "US",
+  "united states of america": "US",
+  america: "US",
+  ca: "CA",
+  can: "CA",
+  canada: "CA",
+  uk: "GB",
+  gb: "GB",
+  "united kingdom": "GB",
+  england: "GB",
+  italy: "IT",
+  france: "FR",
+  spain: "ES",
+  germany: "DE",
+  netherlands: "NL",
+  belgium: "BE",
+  switzerland: "CH",
+  ireland: "IE",
+  portugal: "PT",
+  sweden: "SE",
+  norway: "NO",
+  finland: "FI",
+  denmark: "DK",
+  poland: "PL",
+  india: "IN",
+  singapore: "SG",
+  australia: "AU",
+  "new zealand": "NZ",
+  brazil: "BR",
+  mexico: "MX",
+  japan: "JP",
+  "south korea": "KR",
+  korea: "KR",
+  china: "CN",
+  uae: "AE",
+  israel: "IL",
+};
+
+const US_STATES: Record<string, string> = {
+  AL: "Alabama",
+  AK: "Alaska",
+  AZ: "Arizona",
+  AR: "Arkansas",
+  CA: "California",
+  CO: "Colorado",
+  CT: "Connecticut",
+  DE: "Delaware",
+  FL: "Florida",
+  GA: "Georgia",
+  HI: "Hawaii",
+  ID: "Idaho",
+  IL: "Illinois",
+  IN: "Indiana",
+  IA: "Iowa",
+  KS: "Kansas",
+  KY: "Kentucky",
+  LA: "Louisiana",
+  ME: "Maine",
+  MD: "Maryland",
+  MA: "Massachusetts",
+  MI: "Michigan",
+  MN: "Minnesota",
+  MS: "Mississippi",
+  MO: "Missouri",
+  MT: "Montana",
+  NE: "Nebraska",
+  NV: "Nevada",
+  NH: "New Hampshire",
+  NJ: "New Jersey",
+  NM: "New Mexico",
+  NY: "New York",
+  NC: "North Carolina",
+  ND: "North Dakota",
+  OH: "Ohio",
+  OK: "Oklahoma",
+  OR: "Oregon",
+  PA: "Pennsylvania",
+  RI: "Rhode Island",
+  SC: "South Carolina",
+  SD: "South Dakota",
+  TN: "Tennessee",
+  TX: "Texas",
+  UT: "Utah",
+  VT: "Vermont",
+  VA: "Virginia",
+  WA: "Washington",
+  WV: "West Virginia",
+  WI: "Wisconsin",
+  WY: "Wyoming",
+  DC: "District of Columbia",
+};
+
+const CANADA_PROVINCES: Record<string, string> = {
+  AB: "Alberta",
+  BC: "British Columbia",
+  MB: "Manitoba",
+  NB: "New Brunswick",
+  NL: "Newfoundland and Labrador",
+  NS: "Nova Scotia",
+  NT: "Northwest Territories",
+  NU: "Nunavut",
+  ON: "Ontario",
+  PE: "Prince Edward Island",
+  QC: "Quebec",
+  SK: "Saskatchewan",
+  YT: "Yukon",
+};
+
+const CITY_ALIAS_MAP: Record<string, string> = {
+  sf: "San Francisco",
+  nyc: "New York",
+  la: "Los Angeles",
+};
+
+const CANONICAL_ACCENTED_CITY: Record<string, string> = {
+  montreal: "Montréal",
+  quebec: "Québec",
+};
+
+function normalizeText(text: string): string {
+  return text
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function toSlug(value: string): string {
+  return normalizeText(value).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function cleanRawLocation(rawLocation: string): string {
+  return rawLocation
+    .replace(/\s+/g, " ")
+    .replace(/\s*,\s*/g, ", ")
+    .replace(/\s+-\s+/g, " - ")
+    .trim();
+}
+
+function stripDecorators(text: string): string {
+  return text
+    .replace(/\bgreater\b/gi, "")
+    .replace(/\bmetro(politan)?\b/gi, "")
+    .replace(/\bmetropolitan city of\b/gi, "")
+    .replace(/\barea\b/gi, "")
+    .replace(/\bregion\b/gi, "")
+    .replace(/\s+/g, " ")
+    .replace(/,\s*,/g, ",")
+    .trim();
+}
+
+function resolveCountry(input: string | null): { code: string | null; name: string | null } {
+  if (!input) return { code: null, name: null };
+  const key = normalizeText(input);
+  const code = COUNTRY_ALIAS_TO_CODE[key] || null;
+  if (!code) return { code: null, name: null };
+  return { code, name: COUNTRY_CODE_TO_NAME[code] || null };
+}
+
+function resolveRegion(
+  input: string | null,
+  preferredCountryCode: string | null
+): { code: string | null; name: string | null; countryCode: string | null } {
+  if (!input) return { code: null, name: null, countryCode: preferredCountryCode };
+  const compact = input.trim();
+  const upper = compact.toUpperCase();
+  const key = normalizeText(compact);
+
+  if (preferredCountryCode === "CA" || !preferredCountryCode) {
+    if (CANADA_PROVINCES[upper]) {
+      return { code: upper, name: CANADA_PROVINCES[upper], countryCode: "CA" };
+    }
+    const province = Object.entries(CANADA_PROVINCES).find(
+      ([, v]) => normalizeText(v) === key
+    );
+    if (province) return { code: province[0], name: province[1], countryCode: "CA" };
+  }
+
+  if (preferredCountryCode === "US" || !preferredCountryCode) {
+    if (US_STATES[upper]) {
+      return { code: upper, name: US_STATES[upper], countryCode: "US" };
+    }
+    const state = Object.entries(US_STATES).find(([, v]) => normalizeText(v) === key);
+    if (state) return { code: state[0], name: state[1], countryCode: "US" };
+  }
+
+  return { code: null, name: titleCase(compact), countryCode: preferredCountryCode };
+}
+
+function canonicalCity(input: string | null): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const alias = CITY_ALIAS_MAP[normalizeText(trimmed)];
+  const city = alias || titleCase(trimmed);
+  return CANONICAL_ACCENTED_CITY[normalizeText(city)] || city;
+}
+
+function classifyType(raw: string): WorkLocationType {
+  const lowered = normalizeText(raw);
+  if (/\bremote\b/.test(lowered)) return "remote";
+  if (/\bhybrid\b/.test(lowered)) return "hybrid";
+  return "onsite";
+}
+
+export function normalizeLocation(rawLocation: string): NormalizedJobLocation {
+  const cacheKey = rawLocation || "";
+  const cached = locationCache.get(cacheKey);
+  if (cached) return cached;
+
+  const cleaned = cleanRawLocation(rawLocation || "");
+  const locationType = classifyType(cleaned);
+  const stripped = stripDecorators(cleaned);
+  const parts = stripped
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  let city: string | null = null;
+  let region: string | null = null;
+  let regionCode: string | null = null;
+  let country: string | null = null;
+  let countryCode: string | null = null;
+
+  if (parts.length >= 3) {
+    city = canonicalCity(parts[0]);
+    const r = resolveRegion(parts[1], null);
+    region = r.name;
+    regionCode = r.code;
+    const c = resolveCountry(parts[2]);
+    country = c.name;
+    countryCode = c.code;
+    if (!countryCode && r.countryCode) {
+      countryCode = r.countryCode;
+      country = COUNTRY_CODE_TO_NAME[countryCode] || null;
+    }
+  } else if (parts.length === 2) {
+    city = canonicalCity(parts[0]);
+    const c = resolveCountry(parts[1]);
+    if (c.code) {
+      countryCode = c.code;
+      country = c.name;
+    } else {
+      const r = resolveRegion(parts[1], null);
+      region = r.name;
+      regionCode = r.code;
+      countryCode = r.countryCode;
+      country = countryCode ? COUNTRY_CODE_TO_NAME[countryCode] : null;
+    }
+  } else if (parts.length === 1) {
+    const single = parts[0];
+    const c = resolveCountry(single);
+    if (c.code) {
+      countryCode = c.code;
+      country = c.name;
+    } else {
+      const r = resolveRegion(single, null);
+      if (r.code) {
+        region = r.name;
+        regionCode = r.code;
+        countryCode = r.countryCode;
+        country = countryCode ? COUNTRY_CODE_TO_NAME[countryCode] : null;
+      } else {
+        city = canonicalCity(single);
+      }
+    }
+  }
+
+  if ((locationType === "remote" || locationType === "hybrid") && parts.length > 0) {
+    const inMatch = cleaned.match(/\bin\s+([A-Za-z ]+)$/i);
+    if (inMatch?.[1]) {
+      const c = resolveCountry(inMatch[1]);
+      if (c.code) {
+        countryCode = c.code;
+        country = c.name;
+      }
+    }
+  }
+
+  if (!countryCode && regionCode && CANADA_PROVINCES[regionCode]) {
+    countryCode = "CA";
+    country = COUNTRY_CODE_TO_NAME.CA;
+  }
+  if (!countryCode && regionCode && US_STATES[regionCode]) {
+    countryCode = "US";
+    country = COUNTRY_CODE_TO_NAME.US;
+  }
+
+  const unresolved = !(country || region || city);
+  const result: NormalizedJobLocation = {
+    raw: rawLocation || "",
+    normalized: {
+      city,
+      region,
+      region_code: regionCode,
+      country,
+      country_code: countryCode,
+    },
+    type: locationType,
+    unresolved,
+    confidence: unresolved ? 0.2 : country ? 1 : 0.7,
+  };
+  locationCache.set(cacheKey, result);
+  return result;
+}
+
+export function normalizeLocations(rawLocations: string[]): NormalizedJobLocation[] {
+  const seen = new Set<string>();
+  const normalized: NormalizedJobLocation[] = [];
+  for (const raw of rawLocations || []) {
+    const entry = normalizeLocation(raw);
+    const key = [
+      entry.type,
+      entry.normalized.country_code || entry.normalized.country || "",
+      entry.normalized.region_code || entry.normalized.region || "",
+      entry.normalized.city || "",
+    ].join("::");
+    if (!seen.has(key)) {
+      seen.add(key);
+      normalized.push(entry);
+    }
+  }
+  return normalized;
+}
+
+function normalizeOptionList(options: LocationFilterOption[]): LocationFilterOption[] {
+  return options.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function buildFilterIndex(locations: NormalizedJobLocation[]): LocationFilterIndex {
+  const countryMap = new Map<string, string>();
+  const statesByCountry = new Map<string, Map<string, string>>();
+  const citiesByCountry = new Map<string, Map<string, string>>();
+  const citiesByCountryState = new Map<string, Map<string, string>>();
+
+  for (const location of locations) {
+    if (location.unresolved) continue;
+    if (location.type !== "onsite" && location.type !== "hybrid") continue;
+    const cCode = location.normalized.country_code;
+    const cName = location.normalized.country;
+    if (!cCode || !cName) continue;
+    countryMap.set(cCode, cName);
+
+    const regionKey = location.normalized.region_code || (location.normalized.region ? toSlug(location.normalized.region) : "");
+    if (location.normalized.region && regionKey) {
+      if (!statesByCountry.has(cCode)) statesByCountry.set(cCode, new Map());
+      statesByCountry.get(cCode)!.set(regionKey, location.normalized.region);
+    }
+
+    if (location.normalized.city) {
+      const cityKey = toSlug(location.normalized.city);
+      if (!citiesByCountry.has(cCode)) citiesByCountry.set(cCode, new Map());
+      citiesByCountry.get(cCode)!.set(cityKey, location.normalized.city);
+
+      const stateScope = `${cCode}::${regionKey || "__none__"}`;
+      if (!citiesByCountryState.has(stateScope)) citiesByCountryState.set(stateScope, new Map());
+      citiesByCountryState.get(stateScope)!.set(cityKey, location.normalized.city);
+    }
+  }
+
+  const countries = normalizeOptionList(
+    Array.from(countryMap.entries()).map(([value, label]) => ({ value, label }))
+  );
+
+  const statesObj: Record<string, LocationFilterOption[]> = {};
+  for (const [countryCode, states] of statesByCountry.entries()) {
+    statesObj[countryCode] = normalizeOptionList(
+      Array.from(states.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  const citiesCountryObj: Record<string, LocationFilterOption[]> = {};
+  for (const [countryCode, cities] of citiesByCountry.entries()) {
+    citiesCountryObj[countryCode] = normalizeOptionList(
+      Array.from(cities.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  const citiesCountryStateObj: Record<string, LocationFilterOption[]> = {};
+  for (const [scope, cities] of citiesByCountryState.entries()) {
+    citiesCountryStateObj[scope] = normalizeOptionList(
+      Array.from(cities.entries()).map(([value, label]) => ({ value, label }))
+    );
+  }
+
+  return {
+    countries,
+    statesByCountry: statesObj,
+    citiesByCountry: citiesCountryObj,
+    citiesByCountryState: citiesCountryStateObj,
+  };
+}
+
+export function matchLocationFilters(
+  locations: NormalizedJobLocation[],
+  filters: { countryCode: string; regionKey: string; cityKey: string }
+): boolean {
+  if (filters.countryCode === "all") return true;
+  return locations.some((location) => {
+    const countryOk =
+      location.normalized.country_code === filters.countryCode ||
+      normalizeText(location.normalized.country || "") === normalizeText(filters.countryCode);
+    if (!countryOk) return false;
+
+    if (filters.regionKey !== "all") {
+      const regionKey =
+        location.normalized.region_code ||
+        (location.normalized.region ? toSlug(location.normalized.region) : "");
+      if (regionKey !== filters.regionKey) return false;
+    }
+
+    if (filters.cityKey !== "all") {
+      const cityKey = location.normalized.city ? toSlug(location.normalized.city) : "";
+      if (cityKey !== filters.cityKey) return false;
+    }
+    return true;
+  });
+}
+
+export function normalizeSearchText(input: string): string {
+  return normalizeText(input);
+}
+
+export function formatLocationForDisplay(locations: NormalizedJobLocation[]): string {
+  const display = new Set<string>();
+  for (const location of locations) {
+    if (location.type === "remote") {
+      const country = location.normalized.country;
+      display.add(country ? `Remote (${country})` : "Remote");
+      continue;
+    }
+    const parts = [
+      location.normalized.city,
+      location.normalized.region_code || location.normalized.region,
+      location.normalized.country_code,
+    ].filter(Boolean);
+    if (parts.length) {
+      display.add(parts.join(", "));
+    } else if (location.raw.trim()) {
+      display.add(location.raw.trim());
+    }
+  }
+  return Array.from(display).join(" | ");
+}

--- a/src/types/jobs.ts
+++ b/src/types/jobs.ts
@@ -58,6 +58,19 @@ export interface ExternalJob {
   date_posted: number;
   url: string;
   locations: string[];
+  normalized_locations?: {
+    raw: string;
+    normalized: {
+      city: string | null;
+      region: string | null;
+      region_code: string | null;
+      country: string | null;
+      country_code: string | null;
+    };
+    type: "onsite" | "remote" | "hybrid";
+    unresolved: boolean;
+    confidence: number;
+  }[];
   degrees: string[];
   type: "internship" | "new-grad";
 }


### PR DESCRIPTION
## Summary
- Refactorise les filtres du board jobs avec normalisation géographique structurée.
- Ajoute les filtres facettés multi-sélection (type, catégorie, villes, work mode) avec counts dynamiques.
- Améliore la cascade et les resets explicites pour éviter les incohérences UI.

## Test plan
- [x] Vérifier la cascade pays/état/villes sans pollution cross-level.
- [x] Vérifier la multi-sélection (type/catégorie/work mode/villes).
- [x] Vérifier les counts dynamiques et le tri intelligent des options.

Made with [Cursor](https://cursor.com)