### PR TITLE
fix(alerts): trust the authenticated email and honour weekly frequency

### DIFF
--- a/functions/src/lib/digest-matching.ts
+++ b/functions/src/lib/digest-matching.ts
@@ -11,6 +11,33 @@ export interface DigestSubscriptionLike {
   locations?: string[] | null;
 }
 
+/**
+ * Minimum gap between two sends for a `weekly` subscription. The digest cron
+ * runs daily, so weekly subscribers are skipped until this much time has
+ * passed since their last send. Deliberately 7 days minus 12h of slack: the
+ * scheduler can fire a few minutes late, and a strict 7×24h would drift the
+ * send day forward by one day every week.
+ */
+export const WEEKLY_MIN_INTERVAL_MS =
+  7 * 24 * 60 * 60 * 1000 - 12 * 60 * 60 * 1000;
+
+/**
+ * Whether a subscription should receive a digest in the run happening at
+ * `now`. Daily subscriptions are always due — the cron's own schedule *is*
+ * their cadence. Weekly ones are due only once WEEKLY_MIN_INTERVAL_MS has
+ * passed since `lastSentAtMs`, and immediately if they've never sent (0/null).
+ * Pure so the cadence rule is testable without Firestore.
+ */
+export function isDigestDue(
+  frequency: "daily" | "weekly" | null | undefined,
+  lastSentAtMs: number | null,
+  now: number
+): boolean {
+  if (frequency !== "weekly") return true;
+  if (!lastSentAtMs) return true;
+  return now - lastSentAtMs >= WEEKLY_MIN_INTERVAL_MS;
+}
+
 function tokenize(value: string): string[] {
   return value
     .toLowerCase()

--- a/functions/src/lib/email-service.ts
+++ b/functions/src/lib/email-service.ts
@@ -830,15 +830,23 @@ export const sendEventApprovalEmail = async (
  * unsubscribe link — this is the only confirmation step for v1 (no
  * double opt-in; see docs/specs/04-email-capture.md "Out of scope").
  */
+/** How often a subscription's digest is sent (mirrors the Firestore field). */
+export type AlertFrequency = "daily" | "weekly";
+
 interface JobAlertWelcomeCopy {
-  subject: string;
+  subject: (frequency: AlertFrequency) => string;
   preheader: string;
   kicker: string;
   title: string;
-  subtitle: (whatLine: string) => string;
+  /**
+   * Cadence-aware wording ("each morning" / "once a week") is threaded through
+   * `subject`, `subtitle`, `bullets` and `text` so a weekly subscriber is never
+   * told they'll hear from us every morning.
+   */
+  subtitle: (whatLine: string, frequency: AlertFrequency) => string;
   whatLine: (query: string | null | undefined) => string;
   whatLineText: (query: string | null | undefined) => string;
-  bullets: string[];
+  bullets: (frequency: AlertFrequency) => string[];
   cta: string;
   accountDarkTitle: string;
   accountDarkBody: string;
@@ -851,25 +859,33 @@ interface JobAlertWelcomeCopy {
     whatLineText: string;
     signInUrl: string | undefined;
     unsubscribeUrl: string;
+    frequency: AlertFrequency;
   }) => string;
 }
 
 const JOB_ALERT_WELCOME_CONTENT: Record<Locale, JobAlertWelcomeCopy> = {
   en: {
-    subject: "You're in — daily job alerts from Tail'ed",
+    subject: (frequency) =>
+      frequency === "weekly"
+        ? "You're in — weekly job alerts from Tail'ed"
+        : "You're in — daily job alerts from Tail'ed",
     preheader: "You're subscribed to Tail'ed Community job alerts.",
     kicker: "You're subscribed",
     title: "You're in.",
-    subtitle: (whatLine) =>
-      `You'll now get ${whatLine} delivered to your inbox each morning — free, forever, no spam.`,
+    subtitle: (whatLine, frequency) =>
+      `You'll now get ${whatLine} delivered to your inbox ${
+        frequency === "weekly" ? "once a week" : "each morning"
+      } — free, forever, no spam.`,
     whatLine: (query) =>
       query
         ? `new <strong style="color: #EB7A24;">${escapeHtml(query)}</strong> roles`
         : `new internships and new-grad roles`,
     whatLineText: (query) =>
       query ? `new "${query}" roles` : `new internships and new-grad roles`,
-    bullets: [
-      "One email each morning — only when there are new matches.",
+    bullets: (frequency) => [
+      frequency === "weekly"
+        ? "One email a week — only when there are new matches."
+        : "One email each morning — only when there are new matches.",
       "Apply straight from the email — links go right to the posting.",
       "Your free Tail'ed account is ready — no password to remember.",
       "Unsubscribe anytime, one click.",
@@ -887,20 +903,27 @@ const JOB_ALERT_WELCOME_CONTENT: Record<Locale, JobAlertWelcomeCopy> = {
       `You subscribed to job alerts${
         query ? ` for &quot;${escapeHtml(query)}&quot;` : ""
       } on community.tailed.ca.`,
-    text: ({ whatLineText, signInUrl, unsubscribeUrl }) =>
-      `You're in!\n\nYou'll now get ${whatLineText} delivered to your inbox each morning — free, forever, no spam.\n\nBrowse jobs now: ${EMAIL_SITE_URL}/jobs\n${
+    text: ({ whatLineText, signInUrl, unsubscribeUrl, frequency }) =>
+      `You're in!\n\nYou'll now get ${whatLineText} delivered to your inbox ${
+        frequency === "weekly" ? "once a week" : "each morning"
+      } — free, forever, no spam.\n\nBrowse jobs now: ${EMAIL_SITE_URL}/jobs\n${
         signInUrl
           ? `\nYour free Tail'ed account is ready. Sign in (no password) to edit your alerts and complete your profile:\n${signInUrl}\n`
           : ""
       }\nYour first digest lands as soon as there are fresh matches.\n\nUnsubscribe: ${unsubscribeUrl}\n\n© ${new Date().getFullYear()} Tail'ed. All rights reserved.`,
   },
   fr: {
-    subject: "Ça y est — tes alertes d'emploi quotidiennes de Tail'ed",
+    subject: (frequency) =>
+      frequency === "weekly"
+        ? "Ça y est — tes alertes d'emploi hebdomadaires de Tail'ed"
+        : "Ça y est — tes alertes d'emploi quotidiennes de Tail'ed",
     preheader: "Tu es abonné(e) aux alertes d'emploi de Tail'ed Community.",
     kicker: "Abonnement confirmé",
     title: "Ça y est.",
-    subtitle: (whatLine) =>
-      `Tu recevras désormais ${whatLine} directement dans ta boîte courriel chaque matin — gratuit, pour toujours, sans pourriel.`,
+    subtitle: (whatLine, frequency) =>
+      `Tu recevras désormais ${whatLine} directement dans ta boîte courriel ${
+        frequency === "weekly" ? "une fois par semaine" : "chaque matin"
+      } — gratuit, pour toujours, sans pourriel.`,
     whatLine: (query) =>
       query
         ? `de nouveaux postes <strong style="color: #EB7A24;">${escapeHtml(
@@ -911,8 +934,10 @@ const JOB_ALERT_WELCOME_CONTENT: Record<Locale, JobAlertWelcomeCopy> = {
       query
         ? `de nouveaux postes « ${query} »`
         : `de nouveaux stages et postes pour nouveaux diplômés`,
-    bullets: [
-      "Un seul courriel chaque matin — uniquement quand il y a de nouveaux matchs.",
+    bullets: (frequency) => [
+      frequency === "weekly"
+        ? "Un seul courriel par semaine — uniquement quand il y a de nouveaux matchs."
+        : "Un seul courriel chaque matin — uniquement quand il y a de nouveaux matchs.",
       "Postule directement depuis le courriel — les liens mènent droit à l'offre.",
       "Ton compte Tail'ed gratuit est prêt — aucun mot de passe à retenir.",
       "Désabonne-toi quand tu veux, en un clic.",
@@ -930,8 +955,10 @@ const JOB_ALERT_WELCOME_CONTENT: Record<Locale, JobAlertWelcomeCopy> = {
       `Tu t'es abonné(e) aux alertes d'emploi${
         query ? ` pour &quot;${escapeHtml(query)}&quot;` : ""
       } sur community.tailed.ca.`,
-    text: ({ whatLineText, signInUrl, unsubscribeUrl }) =>
-      `Ça y est !\n\nTu recevras désormais ${whatLineText} directement dans ta boîte courriel chaque matin — gratuit, pour toujours, sans pourriel.\n\nParcourir les emplois : ${EMAIL_SITE_URL}/jobs\n${
+    text: ({ whatLineText, signInUrl, unsubscribeUrl, frequency }) =>
+      `Ça y est !\n\nTu recevras désormais ${whatLineText} directement dans ta boîte courriel ${
+        frequency === "weekly" ? "une fois par semaine" : "chaque matin"
+      } — gratuit, pour toujours, sans pourriel.\n\nParcourir les emplois : ${EMAIL_SITE_URL}/jobs\n${
         signInUrl
           ? `\nTon compte Tail'ed gratuit est prêt. Connecte-toi (sans mot de passe) pour modifier tes alertes et compléter ton profil :\n${signInUrl}\n`
           : ""
@@ -941,30 +968,42 @@ const JOB_ALERT_WELCOME_CONTENT: Record<Locale, JobAlertWelcomeCopy> = {
 
 export const sendJobAlertWelcomeEmail = async (
   email: string,
-  query: string | null | undefined,
-  unsubscribeUrl: string,
-  /**
-   * One-time sign-in link (generated server-side by buildSignInLink). When
-   * present, the email offers one-tap access to the soft account created on
-   * capture. Omitted for already-authenticated subscribers.
-   */
-  signInUrl?: string,
-  locale: Locale = "en"
+  options: {
+    query?: string | null;
+    unsubscribeUrl: string;
+    /**
+     * One-time sign-in link (generated server-side by buildSignInLink). When
+     * present, the email offers one-tap access to the soft account created on
+     * capture. Omitted for already-authenticated subscribers.
+     */
+    signInUrl?: string;
+    locale?: Locale;
+    /** Cadence the subscription was actually created with — drives the copy. */
+    frequency?: AlertFrequency;
+  }
 ) => {
+  const {
+    query,
+    unsubscribeUrl,
+    signInUrl,
+    locale = "en",
+    frequency = "daily",
+  } = options;
   const c = JOB_ALERT_WELCOME_CONTENT[locale];
   const whatLine = c.whatLine(query);
   const whatLineText = c.whatLineText(query);
 
   const mailOptions = {
     to: email,
-    subject: c.subject,
+    subject: c.subject(frequency),
     html: emailShell(
       c.preheader,
-      emailHeader(c.kicker, c.title, c.subtitle(whatLine)) +
+      emailHeader(c.kicker, c.title, c.subtitle(whatLine, frequency)) +
         `
         <tr><td style="padding:22px 30px 6px;">
           <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
-            ${c.bullets
+            ${c
+              .bullets(frequency)
               .map(
                 (t) =>
                   `<tr><td style="padding:7px 0;font:400 14px/1.5 ${EMAIL_FONT};color:#2A1F1A;">${EMAIL_DOT}${t}</td></tr>`
@@ -991,7 +1030,7 @@ export const sendJobAlertWelcomeEmail = async (
             )) +
         emailFooter(c.footerLine(query), unsubscribeUrl, locale)
     ),
-    text: c.text({ whatLineText, signInUrl, unsubscribeUrl }),
+    text: c.text({ whatLineText, signInUrl, unsubscribeUrl, frequency }),
   };
 
   return deliver(mailOptions);
@@ -1572,12 +1611,12 @@ interface DigestCopy {
   subjectWhatDefault: string;
   typeNewGrad: string;
   typeInternship: string;
-  kicker: string;
-  headerTitle: (count: number) => string;
+  kicker: (frequency: AlertFrequency) => string;
+  headerTitle: (count: number, frequency: AlertFrequency) => string;
   headerSubtitle: (whatLine: string) => string;
   whatLine: (query: string | null | undefined) => string;
   whatLineText: (query: string | null | undefined) => string;
-  scopeText: (shown: number, total: number) => string;
+  scopeText: (shown: number, total: number, frequency: AlertFrequency) => string;
   preheader: (scopeText: string) => string;
   browseAll: string;
   darkTitle: string;
@@ -1585,13 +1624,27 @@ interface DigestCopy {
   darkCta: string;
   seeRole: string;
   footerLine: (query: string | null | undefined) => string;
-  textHeading: string;
+  textHeading: (frequency: AlertFrequency) => string;
   textIntro: (whatLineText: string) => string;
-  moreLineText: (shown: number, total: number) => string;
+  moreLineText: (
+    shown: number,
+    total: number,
+    frequency: AlertFrequency
+  ) => string;
   browseAllText: string;
   unsubscribeText: string;
   rightsText: string;
 }
+
+/**
+ * The window a digest covers, in words. Every period-dependent string in
+ * DIGEST_CONTENT reads from here so a weekly digest never claims the roles
+ * landed today.
+ */
+const DIGEST_PERIOD_LABEL: Record<Locale, Record<AlertFrequency, string>> = {
+  en: { daily: "today", weekly: "this week" },
+  fr: { daily: "aujourd'hui", weekly: "cette semaine" },
+};
 
 const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
   en: {
@@ -1601,8 +1654,12 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
     subjectWhatDefault: "job",
     typeNewGrad: "New grad",
     typeInternship: "Internship",
-    kicker: "Daily Job Alert",
-    headerTitle: (count) => `${count} new role${count === 1 ? "" : "s"} today`,
+    kicker: (frequency) =>
+      frequency === "weekly" ? "Weekly Job Alert" : "Daily Job Alert",
+    headerTitle: (count, frequency) =>
+      `${count} new role${count === 1 ? "" : "s"} ${
+        DIGEST_PERIOD_LABEL.en[frequency]
+      }`,
     headerSubtitle: (whatLine) =>
       `Here are the ${whatLine} we found since your last digest.`,
     whatLine: (query) =>
@@ -1611,10 +1668,14 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
         : `new internships and new-grad roles`,
     whatLineText: (query) =>
       query ? `new "${query}" roles` : `new internships and new-grad roles`,
-    scopeText: (shown, total) =>
+    scopeText: (shown, total, frequency) =>
       total > shown
-        ? `Showing the newest ${shown} of ${total} matches today`
-        : `${shown} new match${shown === 1 ? "" : "es"} today`,
+        ? `Showing the newest ${shown} of ${total} matches ${
+            DIGEST_PERIOD_LABEL.en[frequency]
+          }`
+        : `${shown} new match${shown === 1 ? "" : "es"} ${
+            DIGEST_PERIOD_LABEL.en[frequency]
+          }`,
     preheader: (scopeText) =>
       `${scopeText} — fresh roles for your Tail'ed Community alert.`,
     browseAll: "Browse all jobs",
@@ -1627,12 +1688,17 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
       `You subscribed to job alerts${
         query ? ` for &quot;${escapeHtml(query)}&quot;` : ""
       } on community.tailed.ca.`,
-    textHeading: "Your daily job digest",
+    textHeading: (frequency) =>
+      frequency === "weekly"
+        ? "Your weekly job digest"
+        : "Your daily job digest",
     textIntro: (whatLineText) =>
       `Here are the ${whatLineText} we found since your last digest.`,
-    moreLineText: (shown, total) =>
+    moreLineText: (shown, total, frequency) =>
       total > shown
-        ? `\nShowing the newest ${shown} of ${total} matches today.\n`
+        ? `\nShowing the newest ${shown} of ${total} matches ${
+            DIGEST_PERIOD_LABEL.en[frequency]
+          }.\n`
         : "",
     browseAllText: "Browse all jobs",
     unsubscribeText: "Unsubscribe",
@@ -1645,11 +1711,14 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
     subjectWhatDefault: "d'emploi",
     typeNewGrad: "Nouveau diplômé",
     typeInternship: "Stage",
-    kicker: "Alerte d'emploi quotidienne",
-    headerTitle: (count) =>
+    kicker: (frequency) =>
+      frequency === "weekly"
+        ? "Alerte d'emploi hebdomadaire"
+        : "Alerte d'emploi quotidienne",
+    headerTitle: (count, frequency) =>
       `${count} nouveau${count === 1 ? "" : "x"} poste${
         count === 1 ? "" : "s"
-      } aujourd'hui`,
+      } ${DIGEST_PERIOD_LABEL.fr[frequency]}`,
     headerSubtitle: (whatLine) =>
       `Voici ${whatLine} qu'on a trouvés depuis ton dernier résumé.`,
     whatLine: (query) =>
@@ -1662,12 +1731,14 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
       query
         ? `de nouveaux postes « ${query} »`
         : `de nouveaux stages et postes pour nouveaux diplômés`,
-    scopeText: (shown, total) =>
+    scopeText: (shown, total, frequency) =>
       total > shown
-        ? `Les ${shown} matchs les plus récents sur ${total} aujourd'hui`
+        ? `Les ${shown} matchs les plus récents sur ${total} ${
+            DIGEST_PERIOD_LABEL.fr[frequency]
+          }`
         : `${shown} nouveau${shown === 1 ? "" : "x"} match${
             shown === 1 ? "" : "s"
-          } aujourd'hui`,
+          } ${DIGEST_PERIOD_LABEL.fr[frequency]}`,
     preheader: (scopeText) =>
       `${scopeText} — de nouveaux postes pour ton alerte Tail'ed Community.`,
     browseAll: "Parcourir tous les emplois",
@@ -1680,12 +1751,17 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
       `Tu t'es abonné(e) aux alertes d'emploi${
         query ? ` pour &quot;${escapeHtml(query)}&quot;` : ""
       } sur community.tailed.ca.`,
-    textHeading: "Ton résumé d'emplois quotidien",
+    textHeading: (frequency) =>
+      frequency === "weekly"
+        ? "Ton résumé d'emplois hebdomadaire"
+        : "Ton résumé d'emplois quotidien",
     textIntro: (whatLineText) =>
       `Voici ${whatLineText} qu'on a trouvés depuis ton dernier résumé.`,
-    moreLineText: (shown, total) =>
+    moreLineText: (shown, total, frequency) =>
       total > shown
-        ? `\nLes ${shown} matchs les plus récents sur ${total} aujourd'hui.\n`
+        ? `\nLes ${shown} matchs les plus récents sur ${total} ${
+            DIGEST_PERIOD_LABEL.fr[frequency]
+          }.\n`
         : "",
     browseAllText: "Parcourir tous les emplois",
     unsubscribeText: "Se désabonner",
@@ -1694,11 +1770,13 @@ const DIGEST_CONTENT: Record<Locale, DigestCopy> = {
 };
 
 /**
- * Send the daily jobs digest email (WS5). `jobs` must already be capped
+ * Send the jobs digest email (WS5). `jobs` must already be capped
  * (12 max) and sorted newest-first by the caller — this function only
  * renders. Every job link carries `?utm_source=digest&utm_medium=email` so
  * digest -> click is measurable in analytics. `options.locale` defaults to
  * "en"; the caller resolves it from the subscriber's profile.
+ * `options.frequency` is the subscription's cadence and only affects copy
+ * ("today" vs "this week") — the cron decides who is actually due.
  */
 export const sendJobsDigestEmail = async (
   email: string,
@@ -1708,9 +1786,16 @@ export const sendJobsDigestEmail = async (
     unsubscribeUrl: string;
     totalMatchCount: number;
     locale?: Locale;
+    frequency?: AlertFrequency;
   }
 ) => {
-  const { query, unsubscribeUrl, totalMatchCount, locale = "en" } = options;
+  const {
+    query,
+    unsubscribeUrl,
+    totalMatchCount,
+    locale = "en",
+    frequency = "daily",
+  } = options;
   const c = DIGEST_CONTENT[locale];
 
   const subjectWhat = query
@@ -1760,8 +1845,12 @@ export const sendJobsDigestEmail = async (
     .join("\n\n");
 
   const whatLine = c.whatLine(query);
-  const scopeText = c.scopeText(jobs.length, totalMatchCount);
-  const moreLineText = c.moreLineText(jobs.length, totalMatchCount);
+  const scopeText = c.scopeText(jobs.length, totalMatchCount, frequency);
+  const moreLineText = c.moreLineText(
+    jobs.length,
+    totalMatchCount,
+    frequency
+  );
 
   const mailOptions = {
     to: email,
@@ -1769,8 +1858,8 @@ export const sendJobsDigestEmail = async (
     html: emailShell(
       c.preheader(scopeText),
       emailHeader(
-        c.kicker,
-        c.headerTitle(jobs.length),
+        c.kicker(frequency),
+        c.headerTitle(jobs.length, frequency),
         c.headerSubtitle(whatLine)
       ) +
         `
@@ -1794,7 +1883,7 @@ export const sendJobsDigestEmail = async (
         ) +
         emailFooter(c.footerLine(query), unsubscribeUrl, locale)
     ),
-    text: `${c.textHeading}\n\n${c.textIntro(
+    text: `${c.textHeading(frequency)}\n\n${c.textIntro(
       c.whatLineText(query)
     )}\n\n${rowsText}\n${moreLineText}\n${c.browseAllText}: ${EMAIL_SITE_URL}/jobs\n\n${
       c.unsubscribeText

--- a/functions/src/routes/alerts.ts
+++ b/functions/src/routes/alerts.ts
@@ -154,8 +154,14 @@ async function deleteDigestRuns(alertRef: FirebaseFirestore.DocumentReference): 
   }
 }
 
+/**
+ * `email` is optional on purpose: an authenticated caller's address is taken
+ * from their verified ID token and the body value is ignored entirely (see the
+ * handler), so the frontend doesn't have to send — or ask for — an email it
+ * already knows. It stays required for anonymous captures.
+ */
 const subscribeSchema = z.object({
-  email: z.string().trim().toLowerCase().email().max(254),
+  email: z.string().trim().toLowerCase().email().max(254).optional(),
   source: z.enum([
     "search",
     "landing_strip",
@@ -168,6 +174,7 @@ const subscribeSchema = z.object({
   query: z.string().trim().max(200).optional().nullable(),
   locations: z.array(z.string().trim().max(100)).max(10).optional().nullable(),
   jobType: z.enum(["internship", "new-grad"]).optional().nullable(),
+  frequency: z.enum(["daily", "weekly"]).optional(),
 });
 
 /**
@@ -175,6 +182,13 @@ const subscribeSchema = z.object({
  * Public — no auth required. Creates (or, on duplicate, updates) a job-alert
  * subscription. Always responds { success: true } on valid input; never
  * blocks the caller's underlying action (search/save/RSVP/etc).
+ *
+ * Address of record: for an authenticated caller it is ALWAYS the ID token's
+ * email — a body `email` is ignored, so a signed-in user can't point a digest
+ * (or the welcome email, which carries a one-tap sign-in link) at someone
+ * else's inbox. Only anonymous captures may supply an address, and those are
+ * unverified single opt-in by design (spec 04), rate-limited by the per-email
+ * subscription cap below and revocable from every email's unsubscribe link.
  */
 router.post("/subscribe", async (req: Request, res: Response) => {
   try {
@@ -186,7 +200,27 @@ router.post("/subscribe", async (req: Request, res: Response) => {
       });
     }
 
-    const { email, source, query, locations, jobType } = validationResult.data;
+    const {
+      email: bodyEmail,
+      source,
+      query,
+      locations,
+      jobType,
+      frequency = "daily",
+    } = validationResult.data;
+
+    const authedEmail = req.user?.email?.trim().toLowerCase() || null;
+    if (authedEmail && bodyEmail && bodyEmail !== authedEmail) {
+      // Not an error for the caller — we just never honour it. Logged because
+      // a legitimate frontend has no reason to send a different address.
+      console.warn(
+        `alerts/subscribe: ignoring body email for authenticated uid ${req.user?.uid} (source: ${source})`
+      );
+    }
+    const email = authedEmail ?? bodyEmail ?? null;
+    if (!email) {
+      return res.status(400).json({ error: "An email address is required" });
+    }
     // Shared field normalization (empty query/locations → null, absent jobType → null).
     // Pass all three keys explicitly so every field is normalized even when omitted.
     const normalized = normalizeAlertFields({ query, locations, jobType });
@@ -253,6 +287,9 @@ router.post("/subscribe", async (req: Request, res: Response) => {
       await existingDoc.ref.update({
         locations: normalizedLocations,
         source,
+        // Re-subscribing with a different cadence must move the existing row,
+        // otherwise the dedupe branch would silently keep the old schedule.
+        frequency,
         userId: existingData.userId || userId,
         updatedAt: new Date(),
       });
@@ -277,7 +314,7 @@ router.post("/subscribe", async (req: Request, res: Response) => {
       query: normalizedQuery,
       locations: normalizedLocations,
       jobType: normalizedJobType,
-      frequency: "daily",
+      frequency,
       active: true,
       unsubscribeToken,
       userId,
@@ -321,13 +358,13 @@ router.post("/subscribe", async (req: Request, res: Response) => {
         }
       }
 
-      await sendJobAlertWelcomeEmail(
-        email,
-        normalizedQuery,
+      await sendJobAlertWelcomeEmail(email, {
+        query: normalizedQuery,
         unsubscribeUrl,
         signInUrl,
-        welcomeLocale
-      );
+        locale: welcomeLocale,
+        frequency,
+      });
     } catch (emailError) {
       console.error(`Failed to send job alert welcome email to ${email}:`, emailError);
       // Don't fail the subscription if the welcome email fails to send.

--- a/functions/src/scheduled/jobs-digest.ts
+++ b/functions/src/scheduled/jobs-digest.ts
@@ -2,7 +2,11 @@ import { onSchedule } from "firebase-functions/v2/scheduler";
 import { FieldPath, type Timestamp } from "firebase-admin/firestore";
 import { db } from "../lib/firebase";
 import { fetchDigestJobs, type DigestJob } from "../lib/jobs-feed";
-import { matchJobsToSubscription, type DigestSubscriptionLike } from "../lib/digest-matching";
+import {
+  isDigestDue,
+  matchJobsToSubscription,
+  type DigestSubscriptionLike,
+} from "../lib/digest-matching";
 import { sendJobsDigestEmail } from "../lib/email-service";
 import { buildUnsubscribeUrl } from "../lib/links";
 import { getPreferredLocaleForUid, type Locale } from "../lib/locale";
@@ -22,6 +26,10 @@ interface JobAlertSubscriptionDoc extends DigestSubscriptionLike {
   unsubscribeToken: string;
   createdAt: Timestamp | Date | null;
   lastSentJobDate: number | null;
+  /** Cadence chosen by the subscriber. Legacy docs without it are daily. */
+  frequency: "daily" | "weekly";
+  /** When this subscription last received a digest — the weekly cadence gate. */
+  lastSentAt: Timestamp | Date | null;
   /** owning profile uid (null for anonymous captures) — used to resolve locale. */
   userId: string | null;
 }
@@ -47,6 +55,11 @@ function computeWatermark(sub: JobAlertSubscriptionDoc, now: number): number {
   }
   const createdAtMs = toEpochMs(sub.createdAt);
   return Math.max(createdAtMs, now - NEVER_SENT_LOOKBACK_MS);
+}
+
+/** Cadence gate for one subscription — see `isDigestDue` for the rule. */
+function isDue(sub: JobAlertSubscriptionDoc, now: number): boolean {
+  return isDigestDue(sub.frequency, toEpochMs(sub.lastSentAt) || null, now);
 }
 
 async function fetchActiveSubscriptions(): Promise<JobAlertSubscriptionDoc[]> {
@@ -79,6 +92,8 @@ async function fetchActiveSubscriptions(): Promise<JobAlertSubscriptionDoc[]> {
         unsubscribeToken: data.unsubscribeToken,
         createdAt: data.createdAt ?? null,
         lastSentJobDate: typeof data.lastSentJobDate === "number" ? data.lastSentJobDate : null,
+        frequency: data.frequency === "weekly" ? "weekly" : "daily",
+        lastSentAt: data.lastSentAt ?? null,
         userId: typeof data.userId === "string" ? data.userId : null,
       });
     }
@@ -115,13 +130,16 @@ export interface RunJobsDigestSummary {
   subscribers: number;
   emailsSent: number;
   skippedNoMatches: number;
+  /** Weekly subscriptions whose next send isn't due yet in this run. */
+  skippedNotDue: number;
   errors: number;
 }
 
 /**
- * Runs one pass of the daily jobs digest: fetches the feed once, then for
- * every active subscription computes new matches since its watermark, caps
- * at 12, sends (unless dryRun), and advances the watermark on success only.
+ * Runs one pass of the jobs digest: fetches the feed once, then for every
+ * active subscription that is due in this run (see `isDue` — daily always,
+ * weekly once a week) computes new matches since its watermark, caps at 12,
+ * sends (unless dryRun), and advances the watermark on success only.
  * Exported as a plain function so it's directly callable from the dry-run
  * script without going through the Cloud Scheduler trigger.
  */
@@ -135,6 +153,7 @@ export async function runJobsDigest(
     subscribers: 0,
     emailsSent: 0,
     skippedNoMatches: 0,
+    skippedNotDue: 0,
     errors: 0,
   };
 
@@ -165,6 +184,14 @@ export async function runJobsDigest(
 
   await runWithConcurrency(subscriptions, SEND_CONCURRENCY, async (sub) => {
     try {
+      // Cadence gate first — a weekly subscriber that isn't due yet must not
+      // have its watermark advanced, or the roles it skipped today would never
+      // appear in the digest it does receive.
+      if (!isDue(sub, now)) {
+        summary.skippedNotDue += 1;
+        return;
+      }
+
       const watermark = computeWatermark(sub, now);
       const candidates = jobs.filter((job) => job.dateAddedMs > watermark);
       const matched = matchJobsToSubscription(candidates, sub);
@@ -186,6 +213,7 @@ export async function runJobsDigest(
         console.log("jobs-digest[dry-run] would send", {
           subscriptionId: sub.id,
           email: sub.email,
+          frequency: sub.frequency,
           query: sub.query,
           jobType: sub.jobType,
           locations: sub.locations,
@@ -202,6 +230,7 @@ export async function runJobsDigest(
         unsubscribeUrl,
         totalMatchCount: matched.length,
         locale,
+        frequency: sub.frequency,
       });
 
       // Atomically advance the subscription watermark AND record the batch

--- a/functions/src/scripts/run-digest-dry.ts
+++ b/functions/src/scripts/run-digest-dry.ts
@@ -4,8 +4,8 @@
  * Usage: `npm --prefix functions run digest:dry`
  *
  * Step 1 (always runs, no network/Firestore needed): a handful of inline
- * unit tests against the pure `matchJobsToSubscription` function. Exits
- * non-zero immediately if any assertion fails.
+ * unit tests against the pure `matchJobsToSubscription` and `isDigestDue`
+ * functions. Exits non-zero immediately if any assertion fails.
  *
  * Step 2 (best-effort): attempts a real dry run — `runJobsDigest({ dryRun:
  * true })` — which fetches the live jobs feed and reads real
@@ -14,7 +14,11 @@
  * this environment, this step is skipped with a clear message; it never
  * fails the script (the match tests are the pass/fail signal).
  */
-import { matchJobsToSubscription } from "../lib/digest-matching";
+import {
+  isDigestDue,
+  matchJobsToSubscription,
+  WEEKLY_MIN_INTERVAL_MS,
+} from "../lib/digest-matching";
 import type { DigestJob } from "../lib/jobs-feed";
 
 function makeJob(overrides: Partial<DigestJob>): DigestJob {
@@ -181,11 +185,45 @@ test("combined filters (query + jobType + locations) must all pass", () => {
   assert(result.length === 1 && result[0].id === "match", "expected only the fully-matching job to pass all filters");
 });
 
+console.log("\nRunning isDigestDue (cadence gate) inline tests...\n");
+
+const NOW = Date.parse("2026-07-29T11:30:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+test("daily subscriptions are always due", () => {
+  assert(isDigestDue("daily", NOW - 60_000, NOW), "expected a daily sub sent a minute ago to still be due");
+  assert(isDigestDue(undefined, NOW - 60_000, NOW), "expected a legacy sub with no frequency to be treated as daily");
+});
+
+test("weekly subscriptions that have never sent are due immediately", () => {
+  assert(isDigestDue("weekly", null, NOW), "expected a never-sent weekly sub to be due");
+  assert(isDigestDue("weekly", 0, NOW), "expected an epoch-zero lastSentAt to count as never-sent");
+});
+
+test("weekly subscriptions are skipped until a week has passed", () => {
+  assert(!isDigestDue("weekly", NOW - DAY_MS, NOW), "expected a weekly sub sent yesterday to be skipped");
+  assert(!isDigestDue("weekly", NOW - 6 * DAY_MS, NOW), "expected a weekly sub sent 6 days ago to be skipped");
+  assert(isDigestDue("weekly", NOW - 7 * DAY_MS, NOW), "expected a weekly sub sent 7 days ago to be due");
+});
+
+test("weekly cadence carries 12h of slack so the send day doesn't drift", () => {
+  // Sent 7 days ago minus 11h — last week's run fired slightly late, this one
+  // slightly early. Must still send rather than slipping to tomorrow.
+  assert(
+    isDigestDue("weekly", NOW - (7 * DAY_MS - 11 * 60 * 60 * 1000), NOW),
+    "expected an 11h-early weekly send to still be due"
+  );
+  assert(
+    !isDigestDue("weekly", NOW - (WEEKLY_MIN_INTERVAL_MS - 60_000), NOW),
+    "expected a send one minute short of the interval to be skipped"
+  );
+});
+
 if (failures > 0) {
-  console.error(`\n${failures} match test(s) FAILED.`);
+  console.error(`\n${failures} test(s) FAILED.`);
   process.exit(1);
 }
-console.log(`\nAll match tests passed.\n`);
+console.log(`\nAll match + cadence tests passed.\n`);
 
 async function runLiveDryRun() {
   try {

--- a/src/components/capture/job-alert-signup.tsx
+++ b/src/components/capture/job-alert-signup.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { Check, Mail } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { apiFetch } from "@/lib/fetch";
-import { studentAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { trackEvent } from "@/lib/analytics";
 import { getStorageFlag, setStorageFlag } from "@/lib/storage-flags";
 
@@ -29,9 +29,10 @@ interface JobAlertSignupProps {
   /** Called after a successful subscribe (e.g. to dismiss a parent prompt/toast). */
   onSubscribed?: () => void;
   /**
-   * Pre-fills (and takes priority over studentAuth.currentUser?.email) —
-   * used after RSVP, where the email was already captured in the
-   * registration form and must not be asked for twice.
+   * Pre-fills the field for logged-out visitors — used after RSVP, where the
+   * email was already captured in the registration form and must not be asked
+   * for twice. Ignored when signed in: that alert always goes to the account's
+   * own address (the API enforces this too).
    */
   defaultEmail?: string;
 }
@@ -48,6 +49,11 @@ export function isJobAlertSubscribed(): boolean {
  * an email address. Used across the landing page, jobs board, job detail,
  * and post-RSVP confirmation. Never blocks the surrounding flow — failures
  * just toast an error and leave the form usable.
+ *
+ * For a signed-in visitor there is nothing to trade: we already have their
+ * address and the backend takes it from their ID token regardless of what the
+ * body says. So they get a single button instead of a field asking for an
+ * email we know — see the `signedIn` branch below.
  */
 export function JobAlertSignup({
   source,
@@ -59,22 +65,24 @@ export function JobAlertSignup({
   onSubscribed,
   defaultEmail,
 }: JobAlertSignupProps) {
+  const { user, loading: authLoading, likelySignedIn } = useAuth();
   const [email, setEmail] = useState(defaultEmail || "");
   const [submitting, setSubmitting] = useState(false);
   const [subscribed, setSubscribed] = useState(() => isJobAlertSubscribed());
 
-  useEffect(() => {
-    if (!email && studentAuth.currentUser?.email) {
-      setEmail(studentAuth.currentUser.email);
-    }
-    // Only prefill once, on mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // While auth is still resolving, trust the prior-session hint so a signed-in
+  // visitor doesn't see the email field flash before the button replaces it.
+  const signedIn = authLoading ? likelySignedIn : !!user;
+  const accountEmail = user?.email ?? null;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const trimmed = email.trim();
-    if (!trimmed || submitting) return;
+    // Signed-in callers send no email at all — the API uses their token's.
+    if ((!signedIn && !trimmed) || submitting) return;
+    // Rendering the signed-in layout off a stale hint: hold the submit until
+    // auth lands, so we never post an email-less body for a logged-out visitor.
+    if (signedIn && authLoading) return;
 
     setSubmitting(true);
     try {
@@ -82,7 +90,7 @@ export function JobAlertSignup({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: trimmed,
+          ...(signedIn ? {} : { email: trimmed }),
           source,
           ...(query ? { query } : {}),
           ...(locations && locations.length > 0 ? { locations } : {}),
@@ -114,6 +122,35 @@ export function JobAlertSignup({
         <Check className="h-4 w-4 text-green-600 shrink-0" aria-hidden="true" />
         <span>You're subscribed to job alerts</span>
       </div>
+    );
+  }
+
+  // Signed in — we already know where to send it. One button, no email field.
+  if (signedIn) {
+    return (
+      <form
+        onSubmit={handleSubmit}
+        className={cn(
+          variant === "card"
+            ? "flex flex-col items-stretch gap-1.5 w-full"
+            : "flex flex-col items-start gap-1 w-full",
+          className,
+        )}
+      >
+        <Button
+          type="submit"
+          size={variant === "card" ? "lg" : "sm"}
+          disabled={submitting || authLoading}
+          className={cn("shrink-0", variant === "card" && "rounded-full w-full")}
+        >
+          {submitting ? "Signing you up…" : "Get job alerts"}
+        </Button>
+        {accountEmail && (
+          <p className="text-xs text-muted-foreground">
+            Sent to {accountEmail}
+          </p>
+        )}
+      </form>
     );
   }
 

--- a/src/pages/home/page.tsx
+++ b/src/pages/home/page.tsx
@@ -163,6 +163,14 @@ export default function HomePage() {
     const [submitting, setSubmitting] = useState(false);
     const [subscribed, setSubscribed] = useState(() => isJobAlertSubscribed());
 
+    // A signed-in visitor has already given us an address (and the API takes it
+    // from their ID token regardless of what we send), so the builder drops the
+    // email field and the Google path entirely — one button, nothing to re-enter.
+    // While auth resolves, trust the prior-session hint so the signed-in layout
+    // doesn't flash the logged-out one.
+    const { user, loading: authLoading, likelySignedIn } = useAuth();
+    const signedIn = authLoading ? likelySignedIn : !!user;
+
     const alertSectionRef = useRef<HTMLElement>(null);
     const keywordInputRef = useRef<HTMLInputElement>(null);
 
@@ -192,15 +200,20 @@ export default function HomePage() {
     async function handleEmailSubmit(e: FormEvent) {
         e.preventDefault();
         const trimmed = email.trim();
-        if (!trimmed || submitting) return;
+        // Signed-in submissions carry no email — the API uses the token's.
+        if ((!signedIn && !trimmed) || submitting) return;
+        // Showing the signed-in layout off a stale hint: hold the submit until
+        // auth lands, so we never post an email-less body for a logged-out visitor.
+        if (signedIn && authLoading) return;
         setSubmitting(true);
         try {
             const response = await apiFetch("/alerts/subscribe", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                    email: trimmed,
+                    ...(signedIn ? {} : { email: trimmed }),
                     source: "landing_strip",
+                    frequency,
                     ...(alertQuery.trim() ? { query: alertQuery.trim() } : {}),
                     ...(jobType ? { jobType } : {}),
                 }),
@@ -474,7 +487,9 @@ export default function HomePage() {
                             <div className="flex flex-col items-center gap-3 py-4 text-center">
                                 <MilestoneBadge size={64} />
                                 <p className="joy-display text-lg font-bold text-joy-ink">
-                                    You&apos;re in — first digest tomorrow morning
+                                    {frequency === "weekly"
+                                        ? "You're in — first digest within the week"
+                                        : "You're in — first digest tomorrow morning"}
                                 </p>
                                 <p className="joy-mono text-sm text-joy-ink-muted">
                                     {scopeSummary(frequency, alertQuery, jobType)}
@@ -544,39 +559,54 @@ export default function HomePage() {
                                 </div>
 
                                 <div className="mt-6">
-                                    <form onSubmit={handleEmailSubmit} className="flex flex-col gap-2 sm:flex-row">
-                                        <input
-                                            type="email"
-                                            required
-                                            value={email}
-                                            onChange={(e) => setEmail(e.target.value)}
-                                            placeholder="you@school.edu"
-                                            className="min-w-0 flex-1 rounded-xl border border-joy-ink/10 bg-white px-3.5 py-2.5 text-sm text-joy-ink placeholder:text-joy-ink/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-joy-grass/60"
-                                        />
-                                        <PlaygroundButton type="submit" className="shrink-0">
-                                            {submitting ? "Signing up…" : "Get alerts"}
-                                        </PlaygroundButton>
-                                    </form>
+                                    {signedIn ? (
+                                        <form onSubmit={handleEmailSubmit}>
+                                            <PlaygroundButton type="submit" className="w-full">
+                                                {submitting ? "Signing up…" : "Get alerts"}
+                                            </PlaygroundButton>
+                                            <p className="mt-1.5 text-center text-xs text-joy-ink-muted">
+                                                {user?.email
+                                                    ? `We'll send them to ${user.email}.`
+                                                    : "We'll send them to your account email."}
+                                            </p>
+                                        </form>
+                                    ) : (
+                                        <>
+                                            <form onSubmit={handleEmailSubmit} className="flex flex-col gap-2 sm:flex-row">
+                                                <input
+                                                    type="email"
+                                                    required
+                                                    value={email}
+                                                    onChange={(e) => setEmail(e.target.value)}
+                                                    placeholder="you@school.edu"
+                                                    className="min-w-0 flex-1 rounded-xl border border-joy-ink/10 bg-white px-3.5 py-2.5 text-sm text-joy-ink placeholder:text-joy-ink/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-joy-grass/60"
+                                                />
+                                                <PlaygroundButton type="submit" className="shrink-0">
+                                                    {submitting ? "Signing up…" : "Get alerts"}
+                                                </PlaygroundButton>
+                                            </form>
 
-                                    <div className="my-5 flex items-center gap-3 text-xs font-bold uppercase tracking-wide text-joy-ink/40">
-                                        <span className="h-px flex-1 bg-joy-ink/15" />
-                                        or
-                                        <span className="h-px flex-1 bg-joy-ink/15" />
-                                    </div>
+                                            <div className="my-5 flex items-center gap-3 text-xs font-bold uppercase tracking-wide text-joy-ink/40">
+                                                <span className="h-px flex-1 bg-joy-ink/15" />
+                                                or
+                                                <span className="h-px flex-1 bg-joy-ink/15" />
+                                            </div>
 
-                                    <div>
-                                        <button
-                                            type="button"
-                                            onClick={handleGoogleContinue}
-                                            className="flex w-full items-center justify-center gap-2.5 rounded-xl border border-joy-ink/12 bg-white px-4 py-2.5 text-sm font-semibold text-joy-ink transition hover:border-joy-ink/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-joy-grass/60"
-                                        >
-                                            <FcGoogle className="h-4 w-4" aria-hidden="true" />
-                                            Continue with Google
-                                        </button>
-                                        <p className="mt-1.5 text-center text-xs text-joy-ink-muted">
-                                            We&apos;ll save this alert.
-                                        </p>
-                                    </div>
+                                            <div>
+                                                <button
+                                                    type="button"
+                                                    onClick={handleGoogleContinue}
+                                                    className="flex w-full items-center justify-center gap-2.5 rounded-xl border border-joy-ink/12 bg-white px-4 py-2.5 text-sm font-semibold text-joy-ink transition hover:border-joy-ink/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-joy-grass/60"
+                                                >
+                                                    <FcGoogle className="h-4 w-4" aria-hidden="true" />
+                                                    Continue with Google
+                                                </button>
+                                                <p className="mt-1.5 text-center text-xs text-joy-ink-muted">
+                                                    We&apos;ll save this alert.
+                                                </p>
+                                            </div>
+                                        </>
+                                    )}
                                 </div>
                             </>
                         )}


### PR DESCRIPTION
POST /alerts/subscribe took the email from the request body even for authenticated callers, so a signed-in user could point a digest — and the welcome email, which carries a one-tap magic sign-in link — at someone else's inbox. The address of record is now always the ID token's email when one is present; a body email is ignored and logged. It stays required for anonymous captures.

The frontend asked signed-in visitors for an email (plus Continue with Google) it already had. The home alert builder and the shared JobAlertSignup surface now render a single button when signed in and send no email at all.

Weekly alerts were never weekly: the builder never sent the toggle, the subscribe schema didn't accept it (docs were hardcoded daily), and the cron ignored frequency entirely. Cadence now flows toggle -> schema -> doc, and a pure isDigestDue() gates the cron at 7 days minus 12h of slack so the send day doesn't drift. EN/FR welcome and digest copy are cadence-aware instead of hardcoding "each morning".

Covered by four new isDigestDue cases in the digest:dry harness.