### PR TITLE
fix(env): repair and validate the URLs that mint magic links

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -3,17 +3,6 @@ on:
     push:
         branches:
             - main
-env:
-    FB_PROJECT_ID: ${{ secrets.FB_PROJECT_ID }}
-    FB_API_KEY: ${{ secrets.FB_API_KEY }}
-    FB_STORAGE_BUCKET: ${{ secrets.FB_STORAGE_BUCKET }}
-    FB_MESSAGING_SENDER_ID: ${{ secrets.FB_MESSAGING_SENDER_ID }}
-    FB_APP_ID: ${{ secrets.FB_APP_ID }}
-    EMAIL_SERVER: ${{ secrets.EMAIL_SERVER }}
-    FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-    GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-    GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
-    TARGET: default
 jobs:
     main:
         name: Deploy to Firebase
@@ -26,21 +15,118 @@ jobs:
               run: |
                   npm i
                   npm install -g firebase-tools
+            # Writes functions/.env, which the Firebase CLI turns into the
+            # deployed runtime's environment variables.
+            #
+            # Secrets are passed through `env:` rather than interpolated into
+            # the script with ${{ }}. Interpolation splices the raw value into
+            # the shell source, so a secret containing a newline, a quote or a
+            # backtick either corrupts the file or executes as code. Read as
+            # environment variables they are just data.
+            #
+            # Every value is trimmed and stripped of CR/LF before it is
+            # written. That is not cosmetic: a trailing space or CR on
+            # FRONTEND_URL is invisible in the GitHub UI, survives into
+            # process.env, and makes firebase-admin reject the passwordless
+            # sign-in continue URL with `auth/invalid-continue-uri`
+            # ("The continue URL must be a valid URL string") on every login.
             - name: Create .env
               working-directory: functions
+              env:
+                  APP_ENV: production
+                  DEVPOST_API_KEY: ${{ secrets.DEVPOST_API_KEY }}
+                  EMAIL_SERVER: ${{ secrets.EMAIL_SERVER }}
+                  EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+                  FB_API_KEY: ${{ secrets.FB_API_KEY }}
+                  FB_APP_ID: ${{ secrets.FB_APP_ID }}
+                  FB_AUTH_DOMAIN: ${{ secrets.FB_AUTH_DOMAIN }}
+                  FB_MESSAGING_SENDER_ID: ${{ secrets.FB_MESSAGING_SENDER_ID }}
+                  FB_PROJECT_ID: ${{ secrets.FB_PROJECT_ID }}
+                  FB_STORAGE_BUCKET: ${{ secrets.FB_STORAGE_BUCKET }}
+                  FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+                  # Origin the magic link lands on (/auth/callback). Defaults
+                  # to FRONTEND_URL when unset; set it only if the two differ.
+                  # Its domain must be in the Firebase authorized-domains list.
+                  AUTH_CONTINUE_URL: ${{ secrets.AUTH_CONTINUE_URL }}
+                  # Public origin of THIS api, for session-less unsubscribe
+                  # links. Derived from FB_PROJECT_ID when unset.
+                  API_PUBLIC_URL: ${{ secrets.API_PUBLIC_URL }}
+                  # Salt for the hashed visitor IPs on share links. The code
+                  # falls back to a constant, which offers no protection in an
+                  # environment that sees real traffic.
+                  SHARE_IP_SALT: ${{ secrets.SHARE_IP_SALT }}
+                  GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
               run: |
-                  touch .env
-                  echo "APP_ENV=production" >> .env
-                  echo "DEVPOST_API_KEY=${{ secrets.DEVPOST_API_KEY }}" >> .env
-                  echo "EMAIL_SERVER=${{ secrets.EMAIL_SERVER }}" >> .env
-                  echo "FB_API_KEY=${{ secrets.FB_API_KEY }}" >> .env
-                  echo "FB_APP_ID=${{ secrets.FB_APP_ID }}" >> .env
-                  echo "FB_AUTH_DOMAIN=${{ secrets.FB_AUTH_DOMAIN }}" >> .env
-                  echo "FB_MESSAGING_SENDER_ID=${{ secrets.FB_MESSAGING_SENDER_ID }}" >> .env
-                  echo "FB_PROJECT_ID=${{ secrets.FB_PROJECT_ID }}" >> .env
-                  echo "FB_STORAGE_BUCKET=${{ secrets.FB_STORAGE_BUCKET }}" >> .env
-                  echo "FRONTEND_URL=${{ secrets.FRONTEND_URL }}" >> .env
-                  echo "GOOGLE_APPLICATION_CREDENTIALS_BASE64=${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" >> .env
+                  set -euo pipefail
+
+                  : > .env
+
+                  # $1 = key, $2 = "required" | "optional"
+                  write_var() {
+                    local key="$1" requirement="$2" value
+                    value="${!key-}"
+                    # Drop CR/LF anywhere (multi-line base64, Windows
+                    # clipboards) then trim surrounding whitespace.
+                    value="$(printf '%s' "$value" | tr -d '\r\n')"
+                    value="${value#"${value%%[![:space:]]*}"}"
+                    value="${value%"${value##*[![:space:]]}"}"
+
+                    if [ -z "$value" ]; then
+                      if [ "$requirement" = required ]; then
+                        echo "::error::Required secret $key is empty or not set. Set it in Settings > Secrets and variables > Actions."
+                        MISSING=1
+                      fi
+                      return 0
+                    fi
+                    printf '%s=%s\n' "$key" "$value" >> .env
+                  }
+
+                  # A URL secret without a scheme passes every presence check
+                  # and then breaks at runtime, so reject it here.
+                  require_url() {
+                    local key="$1" value="${!1-}"
+                    value="$(printf '%s' "$value" | tr -d '\r\n')"
+                    case "$value" in
+                      ""|http://*|https://*) ;;
+                      *)
+                        echo "::error::$key must start with http:// or https:// (got a value without a scheme)."
+                        MISSING=1
+                        ;;
+                    esac
+                  }
+
+                  MISSING=0
+
+                  write_var APP_ENV required
+                  write_var FB_PROJECT_ID required
+                  write_var FB_API_KEY required
+                  write_var FB_APP_ID optional
+                  write_var FB_AUTH_DOMAIN optional
+                  write_var FB_MESSAGING_SENDER_ID optional
+                  write_var FB_STORAGE_BUCKET required
+                  # Without a mail server every email is logged instead of
+                  # sent, so the api refuses to start in production anyway.
+                  write_var EMAIL_SERVER required
+                  write_var EMAIL_FROM optional
+                  write_var FRONTEND_URL required
+                  write_var AUTH_CONTINUE_URL optional
+                  write_var API_PUBLIC_URL optional
+                  write_var SHARE_IP_SALT optional
+                  write_var DEVPOST_API_KEY optional
+                  write_var GOOGLE_APPLICATION_CREDENTIALS_BASE64 optional
+
+                  require_url FRONTEND_URL
+                  require_url AUTH_CONTINUE_URL
+                  require_url API_PUBLIC_URL
+
+                  if [ "$MISSING" -ne 0 ]; then
+                    echo "Refusing to deploy with an incomplete environment." >&2
+                    exit 1
+                  fi
+
+                  # Keys only — never echo the values into a public build log.
+                  echo "Wrote functions/.env with keys:"
+                  cut -d= -f1 .env | sed 's/^/  - /'
             - name: Authenticate to Google Cloud
               uses: google-github-actions/auth@v2
               with:

--- a/functions/src/lib/env.ts
+++ b/functions/src/lib/env.ts
@@ -168,14 +168,60 @@ export const emailFrom = () =>
 const stripTrailingSlash = (url: string) => url.replace(/\/+$/, "");
 
 /**
+ * Reads a URL-shaped variable, normalising the ways a value arrives mangled
+ * from CI: surrounding quotes (a secret pasted with them), leading/trailing
+ * whitespace, and a trailing CR from a Windows clipboard. Every one of those
+ * survives `process.env` intact, and every one of them makes firebase-admin
+ * reject the magic-link continue URL — its validator treats a space, a
+ * newline and a quote alike as illegal URL characters.
+ *
+ * Returns undefined for an absent OR blank value, so callers fall back to
+ * their defaults instead of building a URL on top of "".
+ */
+function readUrlVar(name: string): string | undefined {
+  const raw = process.env[name];
+  if (typeof raw !== "string") return undefined;
+  const cleaned = raw
+    .trim()
+    .replace(/^['"]+|['"]+$/g, "")
+    .trim();
+  return cleaned ? stripTrailingSlash(cleaned) : undefined;
+}
+
+/**
+ * Mirrors firebase-admin's own URL check (`utils/validator.isURL`): an
+ * http(s) URL containing no illegal characters. We re-implement it rather than
+ * import it so a bad value fails ONCE at startup, naming the variable, instead
+ * of surfacing on every sign-in as
+ *   auth/invalid-continue-uri — "The continue URL must be a valid URL string"
+ * which names nothing and sends you reading Firebase docs instead of your
+ * deploy config. Returns a human-readable problem, or null when valid.
+ */
+function urlProblem(value: string): string | null {
+  // Same character class firebase-admin rejects on — notably excludes
+  // whitespace, quotes and backslashes.
+  if (/[^a-z0-9:/?#[\]@!$&'()*+,;=.\-_~%]/i.test(value)) {
+    return "contains a character that is illegal in a URL (a stray quote, space or newline from CI?)";
+  }
+  let protocol: string;
+  try {
+    protocol = new URL(value).protocol;
+  } catch {
+    return "is not a parseable URL (missing the https:// scheme?)";
+  }
+  if (protocol !== "http:" && protocol !== "https:") {
+    return `has scheme "${protocol}" — it must be http:// or https://`;
+  }
+  return null;
+}
+
+/**
  * Public origin of the frontend site. Used for email assets (the logo PNG must
  * be fetchable by mail clients, so this is never localhost) and for job and
  * community links inside emails.
  */
 export function frontendUrl(): string {
-  return stripTrailingSlash(
-    process.env.FRONTEND_URL || "https://community.tailed.ca"
-  );
+  return readUrlVar("FRONTEND_URL") || "https://community.tailed.ca";
 }
 
 /**
@@ -190,8 +236,8 @@ export function frontendUrl(): string {
  * deployed-dev share APP_ENV=dev without any per-machine URL configuration.
  */
 export function authContinueUrl(): string {
-  const configured = process.env.AUTH_CONTINUE_URL;
-  if (configured) return stripTrailingSlash(configured);
+  const configured = readUrlVar("AUTH_CONTINUE_URL");
+  if (configured) return configured;
   if (isStandalone()) return "http://localhost:5174";
   return frontendUrl();
 }
@@ -206,8 +252,8 @@ export function authContinueUrl(): string {
  * pointing at the DEV project — links that would not unsubscribe anyone.
  */
 export function apiPublicUrl(): string {
-  const configured = process.env.API_PUBLIC_URL;
-  if (configured) return stripTrailingSlash(configured);
+  const configured = readUrlVar("API_PUBLIC_URL");
+  if (configured) return configured;
 
   if (isStandalone()) return "http://localhost:3001";
 
@@ -249,8 +295,10 @@ export function assertEnvValid(): void {
   }
 
   if (env !== "emulator" && rt === "cloud") {
-    if (!process.env.FRONTEND_URL) missing.push("FRONTEND_URL");
-    if (!process.env.FB_PROJECT_ID && !process.env.API_PUBLIC_URL) {
+    // Checked through readUrlVar, not raw presence: a secret that CI wrote as
+    // `FRONTEND_URL=` or `FRONTEND_URL=" "` is missing, not configured.
+    if (!readUrlVar("FRONTEND_URL")) missing.push("FRONTEND_URL");
+    if (!process.env.FB_PROJECT_ID && !readUrlVar("API_PUBLIC_URL")) {
       missing.push("FB_PROJECT_ID (or an explicit API_PUBLIC_URL)");
     }
   }
@@ -259,6 +307,29 @@ export function assertEnvValid(): void {
     throw new Error(
       `[env] APP_ENV="${env}" runtime="${rt}" but required configuration is ` +
         `missing:\n  - ${missing.join("\n  - ")}`
+    );
+  }
+
+  // MALFORMED is a separate failure from MISSING, and the one that actually
+  // bit us: `FRONTEND_URL=community.tailed.ca` (no scheme) passes every
+  // presence check above, then makes generateSignInWithEmailLink reject the
+  // continue URL on every single sign-in attempt. Catch it here, once, with
+  // the variable named.
+  const invalid: string[] = [];
+  const checkUrl = (name: string, value: string) => {
+    const problem = urlProblem(value);
+    if (problem) invalid.push(`${name} resolved to "${value}", which ${problem}`);
+  };
+  checkUrl("FRONTEND_URL", frontendUrl());
+  checkUrl("AUTH_CONTINUE_URL", authContinueUrl());
+  if (env !== "emulator") checkUrl("API_PUBLIC_URL", apiPublicUrl());
+
+  if (invalid.length) {
+    throw new Error(
+      `[env] APP_ENV="${env}" runtime="${rt}" but configured URLs are not ` +
+        `usable:\n  - ${invalid.join("\n  - ")}\n` +
+        `Each must be a full origin including the scheme, e.g. ` +
+        `https://community.tailed.ca`
     );
   }
 


### PR DESCRIPTION
Production sign-in failed on every attempt with

  FirebaseAuthError: The continue URL must be a valid URL string
  (auth/invalid-continue-uri)

`buildSignInLink` builds the continue URL from `authContinueUrl()`, which falls back to FRONTEND_URL in the cloud. firebase-admin's own validator rejects a URL for a space, a newline, a quote or a missing scheme — all of which survive a GitHub secret untouched and reach process.env verbatim.

Nothing caught it: `assertEnvValid()` only checked FRONTEND_URL for PRESENCE, and only when the runtime is cloud, so CI's function-discovery load (standalone) never looked at the value at all.

env.ts
- readUrlVar() normalises every URL variable: trims whitespace, strips a trailing CR, drops surrounding quotes, removes trailing slashes, and treats blank as absent so callers keep their defaults.
- urlProblem() mirrors firebase-admin's isURL, and assertEnvValid() now reports MALFORMED separately from MISSING, naming the variable and the resolved value. A scheme-less FRONTEND_URL is a loud startup failure instead of a broken login on every request.

Create .env step
- Secrets arrive via `env:` instead of ${{ }} interpolation, which spliced raw values into the shell source: a newline corrupted the file and a backtick executed.
- Values are stripped of CR/LF and trimmed, which also un-breaks a multi-line GOOGLE_APPLICATION_CREDENTIALS_BASE64.
- Required secrets that resolve empty, and URL secrets without a scheme, now fail the deploy with a ::error:: naming the secret rather than shipping a container that cannot boot.
- Adds AUTH_CONTINUE_URL, API_PUBLIC_URL, EMAIL_FROM and SHARE_IP_SALT (all optional). Logs written keys only, never values.
- Drops the top-level `env:` block: nothing in the job read it — GOOGLE_APPLICATION_CREDENTIALS comes from google-github-actions/auth, and TARGET / GOOGLE_APPLICATION_CREDENTIALS_JSON were unused.

Verified: tsc clean; the run block exercised against trailing-space+CR, scheme-less, absent-secret, injection and happy-path values; and assertEnvValid() driven with K_SERVICE set for each malformed shape, confirming the repaired URL passes firebase-admin's isURL.